### PR TITLE
Add unpkg config

### DIFF
--- a/.changeset/curly-pumpkins-clean.md
+++ b/.changeset/curly-pumpkins-clean.md
@@ -1,0 +1,5 @@
+---
+"@lookit/lookit-initjspsych": patch
+---
+
+Add unpkg config

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Add build script to new package's `package.json`:
   },
 ```
 
+And add the following to `package.json`:
+
+```json
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "src",
+    "dist"
+  ],
+```
+
 At the root of the new package run the following commands:
 
 ```sh

--- a/packages/lookit-initjspsych/package.json
+++ b/packages/lookit-initjspsych/package.json
@@ -9,6 +9,11 @@
   },
   "author": "",
   "license": "ISC",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "src",
+    "dist"
+  ],
   "dependencies": {
     "@jspsych/config": "^2.0.0",
     "jspsych": "^7.3.4"


### PR DESCRIPTION
Currently there is two things that are now working with `unpkg.com`: 

1. The correct file ('dist/index.browser.min.js`) isn't being served.
2. If you for the correct file, the mime type is wrong. 

Adding a few lines to the `package.json` file should help to resolve these issues.  