### PR TITLE
remove lookit-api from ignore in changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["@lookit/lookit-api"]
+  "updateInternalDependencies": "patch"
 }


### PR DESCRIPTION
This PR removes the `lookit-api` package from `ignore` in the changesets config. We were trying to use the ignore parameter to avoid publishing the `@lookit/lookit-api` package, since it doesn't need to be published, but this is causing the following error in the GH release step "Create Release Pull Request or Publish Packages"

>  /opt/hostedtoolcache/node/20.11.1/x64/bin/npx changeset publish
> error ValidationError: Some errors occurred when validating the changesets config:
> error The package "@lookit/lookit-helpers" depends on the ignored package "@lookit/lookit-api", but "@lookit/lookit-helpers" is not being ignored. Please add "@lookit/lookit-helpers" to the `ignore` option.

We can consider alternative solutions, or just leave this as is to continue publishing the lookit-jspsych/lookit-api package.