### PR TITLE
Update setup-node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node v${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm

--- a/packages/lookit-helpers/package.json
+++ b/packages/lookit-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lookit/lookit-helpers",
   "version": "0.0.1",
-  "description": "This package provides researchers with access to user's data for developing thier studies.",
+  "description": "This package provides researchers with access to user's data for developing their studies.",
   "homepage": "https://github.com/lookit/lookit-jspsych#readme",
   "bugs": {
     "url": "https://github.com/lookit/lookit-jspsych/issues"


### PR DESCRIPTION
### Summary

Almost unnecessary updates to GitHub actions.  `setup-node` is now at version 4.

### Open Question

Should I increment the version of helpers to fix the spelling mistake?

### Notes

No `changset` is needed.  No packages will be affected by this change. 