### PR TITLE
Update jsPsych `survey` plugin to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3201,9 +3201,9 @@
       "dev": true
     },
     "node_modules/@jspsych/plugin-survey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jspsych/plugin-survey/-/plugin-survey-1.0.0.tgz",
-      "integrity": "sha512-wcPTfx1EP5FaSS4c0RTzJtKFSJ+cBlTHgjRo4CKFiOgBhEBqiYK6XeEc67a7xVauEt3H98I9mxZlVZdnkwo/3Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jspsych/plugin-survey/-/plugin-survey-1.0.1.tgz",
+      "integrity": "sha512-KcxTGulgqMWekdgZiqXHVZlxxtKslADkRoB04HTAYtcnUoeBpq4ZNJhy2iLO3y+mj0vYigttiS2UecDv5IaPxA==",
       "dependencies": {
         "survey-core": "^1.9.138",
         "survey-knockout-ui": "^1.9.139"
@@ -17895,7 +17895,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@jspsych/plugin-survey": "^1.0.0",
+        "@jspsych/plugin-survey": "^1.0.1",
         "@lookit/data": "^0.0.1",
         "dompurify": "^3.0.11",
         "marked": "^12.0.1",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -24,7 +24,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
-    "@jspsych/plugin-survey": "^1.0.0",
+    "@jspsych/plugin-survey": "^1.0.1",
     "@lookit/data": "^0.0.1",
     "dompurify": "^3.0.11",
     "marked": "^12.0.1",


### PR DESCRIPTION
This PR updates our jsPsych `survey` plugin to v1.0.1, which fixes a bug in the width of dropdown elements (https://github.com/jspsych/jsPsych/issues/3286). 

We'll also need to update the jspsych-study-detail page in the lookit-api to load the updated CSS file:

```html
<link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@1.0.1/css/survey.css">
```