### PR TITLE
Remove iife only build

### DIFF
--- a/rollup.mjs
+++ b/rollup.mjs
@@ -8,19 +8,16 @@ export function makeRollupConfig(iifeName) {
       ...config,
       // Add data package as external dependency
       external: [...config.external, dataPackageName],
-      output: config.output
-        // Only build iife bundles
-        .filter((output) => output.format === "iife")
-        .map((output) => {
-          return {
-            ...output,
-            globals: {
-              ...output.globals,
-              // Explicitly state data's iife name
-              [dataPackageName]: iifeNameData,
-            },
-          };
-        }),
+      output: config.output.map((output) => {
+        return {
+          ...output,
+          globals: {
+            ...output.globals,
+            // Explicitly state data's iife name
+            [dataPackageName]: iifeNameData,
+          },
+        };
+      }),
     };
   });
 }


### PR DESCRIPTION
# Summary

I was running across an issue where packages couldn't reference another package.  This was resolved by adding back in the CommonJS builds.  Easy fix, embarrassing mistake.  