### PR TITLE
Mustache template engine

### DIFF
--- a/jest.cjs
+++ b/jest.cjs
@@ -1,6 +1,11 @@
 module.exports.makePackageConfig = () => {
+  const config = require("@jspsych/config/jest").makePackageConfig(__dirname);
   return {
-    ...require("@jspsych/config/jest").makePackageConfig(__dirname),
+    ...config,
+    transform: {
+      ...config.transform,
+      "^.+\\.mustache$": "<rootDir>/../../jest.text.loader.js",
+    },
     moduleNameMapper: { "@lookit/data": "<rootDir>/../../packages/data/src" },
     coverageThreshold: {
       global: {

--- a/jest.text.loader.js
+++ b/jest.text.loader.js
@@ -1,0 +1,7 @@
+module.exports = {
+  process(sourceText, sourcePath, options) {
+    return {
+      code: `module.exports = ${JSON.stringify(sourceText)};`,
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4138,13 +4138,29 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
+      "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
+      "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4163,13 +4179,59 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
+      "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
+      "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
+      "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
+      "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -5131,6 +5193,12 @@
       "version": "0.7.34",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mustache": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.5.tgz",
+      "integrity": "sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "12.20.55",
@@ -14518,6 +14586,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mute-stdout": {
       "version": "1.0.1",
       "dev": true,
@@ -19244,17 +19320,170 @@
       "license": "ISC",
       "dependencies": {
         "@lookit/data": "^0.0.1",
-        "auto-bind": "^5.0.1"
+        "auto-bind": "^5.0.1",
+        "mustache": "^4.2.0"
       },
       "devDependencies": {
         "@jspsych/config": "^2.0.0",
         "@types/audioworklet": "^0.0.58",
+        "@types/mustache": "^4.2.5",
         "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-dotenv": "^0.5.1"
+        "rollup-plugin-dotenv": "^0.5.1",
+        "rollup-plugin-string-import": "^1.2.4"
       },
       "peerDependencies": {
         "jspsych": "^8.0.2"
       }
+    },
+    "packages/record/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
+      "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
+      "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
+      "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
+      "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
+      "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
+      "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
+      "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
+      "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
+      "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "packages/record/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
+      "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
     },
     "packages/record/node_modules/auto-bind": {
       "version": "5.0.1",
@@ -19264,6 +19493,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/record/node_modules/rollup": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
+      "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.20.0",
+        "@rollup/rollup-android-arm64": "4.20.0",
+        "@rollup/rollup-darwin-arm64": "4.20.0",
+        "@rollup/rollup-darwin-x64": "4.20.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.20.0",
+        "@rollup/rollup-linux-arm64-musl": "4.20.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.20.0",
+        "@rollup/rollup-linux-x64-gnu": "4.20.0",
+        "@rollup/rollup-linux-x64-musl": "4.20.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.20.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.20.0",
+        "@rollup/rollup-win32-x64-msvc": "4.20.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "packages/record/node_modules/rollup-plugin-string-import": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-string-import/-/rollup-plugin-string-import-1.2.4.tgz",
+      "integrity": "sha512-EOeLRDqxo9Mt/TAfSRVU586wId/HY2QkbxN3Qg6iyKIqfFTXi64gUejivy/7kf24WjvxEtIIQoIrnOcqXrDeGA==",
+      "dev": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "peerDependencies": {
+        "rollup": "4.20.0"
       }
     },
     "packages/surveys": {
@@ -21814,13 +22093,132 @@
         "@jspsych/config": "^2.0.0",
         "@lookit/data": "^0.0.1",
         "@types/audioworklet": "^0.0.58",
+        "@types/mustache": "^4.2.5",
         "auto-bind": "^5.0.1",
+        "mustache": "^4.2.0",
         "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-dotenv": "^0.5.1"
+        "rollup-plugin-dotenv": "^0.5.1",
+        "rollup-plugin-string-import": "^1.2.4"
       },
       "dependencies": {
+        "@rollup/rollup-android-arm-eabi": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
+          "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-android-arm64": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
+          "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-darwin-arm64": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
+          "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-darwin-x64": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
+          "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-linux-arm-gnueabihf": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
+          "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-linux-arm64-musl": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
+          "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-linux-x64-musl": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
+          "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-win32-arm64-msvc": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
+          "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-win32-ia32-msvc": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
+          "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "@rollup/rollup-win32-x64-msvc": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
+          "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
         "auto-bind": {
           "version": "5.0.1"
+        },
+        "rollup": {
+          "version": "4.20.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
+          "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@rollup/rollup-android-arm-eabi": "4.20.0",
+            "@rollup/rollup-android-arm64": "4.20.0",
+            "@rollup/rollup-darwin-arm64": "4.20.0",
+            "@rollup/rollup-darwin-x64": "4.20.0",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
+            "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
+            "@rollup/rollup-linux-arm64-gnu": "4.20.0",
+            "@rollup/rollup-linux-arm64-musl": "4.20.0",
+            "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
+            "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
+            "@rollup/rollup-linux-s390x-gnu": "4.20.0",
+            "@rollup/rollup-linux-x64-gnu": "4.20.0",
+            "@rollup/rollup-linux-x64-musl": "4.20.0",
+            "@rollup/rollup-win32-arm64-msvc": "4.20.0",
+            "@rollup/rollup-win32-ia32-msvc": "4.20.0",
+            "@rollup/rollup-win32-x64-msvc": "4.20.0",
+            "@types/estree": "1.0.5",
+            "fsevents": "~2.3.2"
+          }
+        },
+        "rollup-plugin-string-import": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/rollup-plugin-string-import/-/rollup-plugin-string-import-1.2.4.tgz",
+          "integrity": "sha512-EOeLRDqxo9Mt/TAfSRVU586wId/HY2QkbxN3Qg6iyKIqfFTXi64gUejivy/7kf24WjvxEtIIQoIrnOcqXrDeGA==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^5.1.0"
+          }
         }
       }
     },
@@ -22061,10 +22459,18 @@
       "dev": true,
       "optional": true
     },
+    "@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
+      "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
+      "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
       "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
@@ -22074,10 +22480,34 @@
       "dev": true,
       "optional": true
     },
+    "@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
+      "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
+      "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
+      "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
+      "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
       "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
@@ -22781,6 +23211,12 @@
     },
     "@types/ms": {
       "version": "0.7.34",
+      "dev": true
+    },
+    "@types/mustache": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.5.tgz",
+      "integrity": "sha512-PLwiVvTBg59tGFL/8VpcGvqOu3L4OuveNvPi0EYbWchRdEVP++yRUXJPFl+CApKEq13017/4Nf7aQ5lTtHUNsA==",
       "dev": true
     },
     "@types/node": {
@@ -28823,6 +29259,11 @@
     "ms": {
       "version": "2.1.2",
       "dev": true
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
     },
     "mute-stdout": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1117,7 +1117,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.0",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1500,11 +1502,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.1",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -20394,7 +20398,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.24.0",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -20612,10 +20618,12 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.24.1",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.7"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -26,13 +26,16 @@
   },
   "dependencies": {
     "@lookit/data": "^0.0.1",
-    "auto-bind": "^5.0.1"
+    "auto-bind": "^5.0.1",
+    "mustache": "^4.2.0"
   },
   "devDependencies": {
     "@jspsych/config": "^2.0.0",
     "@types/audioworklet": "^0.0.58",
+    "@types/mustache": "^4.2.5",
     "rollup-plugin-copy": "^3.5.0",
-    "rollup-plugin-dotenv": "^0.5.1"
+    "rollup-plugin-dotenv": "^0.5.1",
+    "rollup-plugin-string-import": "^1.2.4"
   },
   "peerDependencies": {
     "jspsych": "^8.0.2"

--- a/packages/record/rollup.config.mjs
+++ b/packages/record/rollup.config.mjs
@@ -1,5 +1,6 @@
 import copy from "rollup-plugin-copy";
 import dotenv from "rollup-plugin-dotenv";
+import { importAsString } from "rollup-plugin-string-import";
 import { makeRollupConfig } from "../../rollup.mjs";
 
 export default makeRollupConfig("chsRecord").map((config) => {
@@ -11,6 +12,10 @@ export default makeRollupConfig("chsRecord").map((config) => {
       dotenv(),
       copy({
         targets: [{ src: "src/mic_check.js", dest: "dist" }],
+      }),
+      // Add support to import mustache template files as strings
+      importAsString({
+        include: ["**/*.mustache"],
       }),
     ],
   };

--- a/packages/record/src/stop.ts
+++ b/packages/record/src/stop.ts
@@ -1,7 +1,9 @@
 import { LookitWindow } from "@lookit/data/dist/types";
 import { JsPsych, JsPsychPlugin } from "jspsych";
+import Mustache from "mustache";
 import { NoSessionRecordingError } from "./error";
 import Recorder from "./recorder";
+import uploadingVideo from "./templates/uploading-video.mustache";
 
 declare let window: LookitWindow;
 
@@ -34,7 +36,7 @@ export default class StopRecordPlugin implements JsPsychPlugin<Info> {
    *   plugin's trial method via jsPsych core).
    */
   public trial(display_element: HTMLElement): void {
-    display_element.innerHTML = "<div>Uploading video, please wait...</div>";
+    display_element.innerHTML = Mustache.render(uploadingVideo, {});
     this.recorder.stop().then(() => {
       window.chs.sessionRecorder = null;
       display_element.innerHTML = "";

--- a/packages/record/src/string-import.d.ts
+++ b/packages/record/src/string-import.d.ts
@@ -1,0 +1,4 @@
+declare module "*.mustache" {
+  const file: string;
+  export default file;
+}

--- a/packages/record/src/templates/uploading-video.mustache
+++ b/packages/record/src/templates/uploading-video.mustache
@@ -1,0 +1,1 @@
+<div>Uploading video, please wait...</div>

--- a/packages/record/src/templates/webcam-feed.mustache
+++ b/packages/record/src/templates/webcam-feed.mustache
@@ -1,0 +1,9 @@
+<video 
+    autoplay 
+    playsinline 
+    muted 
+    id="{{webcam_element_id}}" 
+    width="{{width}}" 
+    height="{{height}}" 
+    style="display:inline-block;">
+</video>

--- a/packages/record/tsconfig.json
+++ b/packages/record/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "esModuleInterop": true,
     "strict": true
   },
   "extends": "@jspsych/config/tsconfig.json",


### PR DESCRIPTION
# Summary

As a developer, writing HTML as strings sucks.  This PR adds a template engine to assist HTML development within JavaScript.  

## Implementation 

I unilaterally decided on [Mustache](https://mustache.github.io/) and the JavaScript implementation [`mustache.js`](https://github.com/janl/mustache.js).  To support the `mustache.js` package, I added the ability to "import" template files as strings.  This should provide an easy path to future HTML development.  This is currently only in the `@lookit/record` package, but it could easily be added to any package.  

## Usage

See [the specification documentation](https://mustache.github.io/) for details on templates.

1. Add your template to the "templates" directory.  Use the "mustache" extension.
2. Import template (e.g. `import templateName from "./templates/template-name.mustache"`).
3. Render the template using the Mustache render function (e.g. `Mustache.render(templateName, view)`).  The second argument "view" is a dictionary containing the values being replaced in the template. 