### PR TITLE
Add text about how to use the doc local dev server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,6 @@ This will create/update a "site" directory in the project root, containing all o
 
 ### Structure
 
-The root MD file is at `packages/index.md` and each packages MD file is located at the root of the packaged. (e.g. Data's md file is located at `packages/data/README.md`.) The structure is defined in `mkdocs.yml`.
+The documentation pages are generated from the README markdown files in the project root directory and the individual package directories. The main project documentation page comes from the root markdown file at `packages/index.md` and the documentation for each package comes from the README markdown files in each package root (e.g. `packages/data/README.md` for the `Data` package.) This documentation structure is defined in `mkdocs.yml`.
 
-The location of each README file might seem odd. We would like to bundle the README file into each package and have `npmjs.com` should use the README file for each package's landing page.
+The reason for having the documentation pages in these different locations throughout the repository is so that they can be re-used as the package's landing page on NPM. This way, the documentation is bundled into each package, and the NPM site `npmjs.com` will automatically use the README.md file as the package's landing page.

--- a/README.md
+++ b/README.md
@@ -161,11 +161,13 @@ To run documentation development server you will need to have Python 3.12 and [P
 make serve
 ```
 
-To build the documentation to static HTML files:
+To build the documentation:
 
 ```
 make build
 ```
+
+This will create/update a "site" directory in the project root, containing all of the static files.
 
 ### Structure
 

--- a/README.md
+++ b/README.md
@@ -152,3 +152,23 @@ lookit-helpers: npm run dev -w @lookit/lookit-helpers
 ```
 
 This method is optional (Honcho should not be added to the project dependencies, and Procfile has been added to our gitignore).
+
+## Documentation
+
+To run documentation development server you will need to have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed. To start the local development server:
+
+```
+make serve
+```
+
+To build the documentation to static HTML files:
+
+```
+make build
+```
+
+### Structure
+
+The root MD file is at `packages/index.md` and each packages MD file is located at the root of the packaged. (e.g. Data's md file is located at `packages/data/README.md`.) The structure is defined in `mkdocs.yml`.
+
+The location of each README file might seem odd. We would like to bundle the README file into each package and have `npmjs.com` should use the README file for each package's landing page.


### PR DESCRIPTION
# Summary

I've added some (clunky) language about how docs are used, updated, and organized.  As always, I welcome any changes to the documentation language.  