### PR TITLE
Change AWS S3 env var names

### DIFF
--- a/.changeset/sharp-toes-learn.md
+++ b/.changeset/sharp-toes-learn.md
@@ -1,0 +1,5 @@
+---
+"@lookit/data": patch
+---
+
+Update AWS environment variable names to avoid naming conflicts with RecordRTC AWS variables.

--- a/packages/data/src/environment.d.ts
+++ b/packages/data/src/environment.d.ts
@@ -1,10 +1,10 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      S3_REGION: string;
-      S3_ACCESS_KEY_ID: string;
-      S3_SECRET_ACCESS_KEY: string;
-      S3_BUCKET: string;
+      JSPSYCH_S3_REGION: string;
+      JSPSYCH_S3_ACCESS_KEY_ID: string;
+      JSPSYCH_S3_SECRET_ACCESS_KEY: string;
+      JSPSYCH_S3_BUCKET: string;
     }
   }
 }

--- a/packages/data/src/lookitS3.ts
+++ b/packages/data/src/lookitS3.ts
@@ -15,7 +15,7 @@ class LookitS3 {
   private s3: S3Client;
   private uploadId: string = "";
   private key: string;
-  private bucket: string = process.env.S3_BUCKET;
+  private bucket: string = process.env.JSPSYCH_S3_BUCKET;
   private complete: boolean = false;
 
   public static readonly minUploadSize: number = 5 * 1024 * 1024;
@@ -30,10 +30,10 @@ class LookitS3 {
     this.key = key;
     try {
       this.s3 = new S3Client({
-        region: process.env.S3_REGION,
+        region: process.env.JSPSYCH_S3_REGION,
         credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+          accessKeyId: process.env.JSPSYCH_S3_ACCESS_KEY_ID,
+          secretAccessKey: process.env.JSPSYCH_S3_SECRET_ACCESS_KEY,
         },
       });
     } catch (e) {


### PR DESCRIPTION
This PR changes the AWS S3 environment variable names used for uploading to the jsPsych video bucket. We used the same environment variable names that are used for EFP (RecordRTC) video uploading, so we need different ones to avoid conflicting variable names in the lookit-api environment.

For local development - remember to also change the variable names in `packages/data/.env`.