### PR TITLE
Hide circular dependency warnings

### DIFF
--- a/.changeset/nice-hats-sing.md
+++ b/.changeset/nice-hats-sing.md
@@ -1,0 +1,9 @@
+---
+"@lookit/lookit-initjspsych": patch
+"@lookit/surveys": patch
+"@lookit/record": patch
+"@lookit/style": patch
+"@lookit/data": patch
+---
+
+Update rollup config to hide known circular warnings

--- a/rollup.mjs
+++ b/rollup.mjs
@@ -1,8 +1,51 @@
+/* eslint-disable func-style */
+
 import { makeRollupConfig as jsPsychMakeRollupConfig } from "@jspsych/config/rollup";
 import { iifeNameData } from "./packages/data/rollup.config.mjs";
 
+/**
+ * Create rollup config for any package.
+ *
+ * @param iifeName - IIFE Name for this package
+ * @returns Rollup config
+ */
 export function makeRollupConfig(iifeName) {
   const dataPackageName = "@lookit/data";
+
+  const knownCircularDeps = [
+    "@smithy/util-stream/dist-es/blob/Uint8ArrayBlobAdapter.js",
+    "@smithy/util-endpoints/dist-es/utils/callFunction.js",
+    "@smithy/util-endpoints/dist-es/utils/getEndpointProperties.js",
+    "@smithy/util-endpoints/dist-es/utils/evaluateRules.js",
+    "@aws-crypto/crc32/build/module/index.js",
+    "@aws-crypto/crc32c/build/module/index.js",
+  ];
+
+  /**
+   * Change warnings into errors. This will help us catch build concerns before
+   * they are in production. Also, hide known circular dependency warnings. This is
+   * copied from Rollup's documentation:
+   * https://rollupjs.org/configuration-options/#onlog
+   *
+   * @param level - Message level
+   * @param log - Log object containing location, frame, and message.
+   * @param handler - Function called to record log.
+   */
+  const onLog = (level, log, handler) => {
+    // Don't log known circular dependencies with the data package.
+    if (log.code === "CIRCULAR_DEPENDENCY" && iifeName === "chsData") {
+      if (knownCircularDeps.some((value) => log.message.includes(value))) {
+        return;
+      }
+    }
+
+    if (level === "warn") {
+      handler("error", log);
+    } else {
+      handler(level, log);
+    }
+  };
+
   return jsPsychMakeRollupConfig(iifeName).map((config) => {
     return {
       ...config,
@@ -18,6 +61,7 @@ export function makeRollupConfig(iifeName) {
           },
         };
       }),
+      onLog,
     };
   });
 }

--- a/rollup.mjs
+++ b/rollup.mjs
@@ -23,8 +23,8 @@ export function makeRollupConfig(iifeName) {
 
   /**
    * Change warnings into errors. This will help us catch build concerns before
-   * they are in production. Also, hide known circular dependency warnings. This is
-   * copied from Rollup's documentation:
+   * they are in production. Also, hide known circular dependency warnings. This
+   * is copied from Rollup's documentation:
    * https://rollupjs.org/configuration-options/#onlog
    *
    * @param level - Message level


### PR DESCRIPTION
# Summary

At this point, we accept that AWS (and its dependencies) will have some circular dependency warnings with Rollup. To hide them without also hiding warnings we'd like to address, I've created a list of strings to identify the warnings we've already run across.  Additionally, I've changed "warnings" to "errors."  This will help catch issues with Rollup before they accidentally end up in production. 