### PR TITLE
Unmuted recorded consent playback

### DIFF
--- a/.changeset/silver-pigs-develop.md
+++ b/.changeset/silver-pigs-develop.md
@@ -1,0 +1,5 @@
+---
+"@lookit/record": patch
+---
+
+Unmute playback of recorded consent video.

--- a/packages/record/src/consentVideo.spec.ts
+++ b/packages/record/src/consentVideo.spec.ts
@@ -2,6 +2,7 @@ import { LookitWindow } from "@lookit/data/dist/types";
 import Handlebars from "handlebars";
 import { initJsPsych, PluginInfo, TrialType } from "jspsych";
 import consentVideoTrial from "../templates/consent-video-trial.hbs";
+import playbackFeed from "../templates/playback-feed.hbs";
 import recordFeed from "../templates/record-feed.hbs";
 import { VideoConsentPlugin } from "./consentVideo";
 import {
@@ -271,4 +272,8 @@ test("nextButton", () => {
     .dispatchEvent(new Event("click"));
 
   expect(jsPsych.finishTrial).toHaveBeenCalledTimes(1);
+});
+
+test("Video playback should not be muted", () => {
+  expect(playbackFeed).not.toContain("muted");
 });

--- a/packages/record/templates/playback-feed.hbs
+++ b/packages/record/templates/playback-feed.hbs
@@ -1,7 +1,6 @@
 <video
   autoplay
   playsinline
-  muted
   src="{{{src}}}"
   id="{{webcam_element_id}}"
   width="{{width}}"


### PR DESCRIPTION
# Summary

This PR is a fix for a small bug where the playback of the recorded consent video was muted by default.