### PR TITLE
Video file names in standard format

### DIFF
--- a/.changeset/rotten-cars-swim.md
+++ b/.changeset/rotten-cars-swim.md
@@ -1,0 +1,6 @@
+---
+"@lookit/record": patch
+---
+
+Change video file names to match existing format, and to pass necessary info to
+AWS Lambda for saving video files to database.

--- a/packages/record/src/consentVideo.spec.ts
+++ b/packages/record/src/consentVideo.spec.ts
@@ -216,7 +216,7 @@ test("recordButton", async () => {
 
   // Start recorder
   expect(Recorder.prototype.start).toHaveBeenCalledTimes(1);
-  expect(Recorder.prototype.start).toHaveBeenCalledWith("consent");
+  expect(Recorder.prototype.start).toHaveBeenCalledWith(true, "consent-video");
 });
 
 test("playButton", () => {

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -234,7 +234,7 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
       play.disabled = true;
       next.disabled = true;
       this.getImg(display, "record-icon").style.visibility = "visible";
-      await this.recorder.start("consent");
+      await this.recorder.start(true, VideoConsentPlugin.info.name);
     });
   }
 

--- a/packages/record/src/index.spec.ts
+++ b/packages/record/src/index.spec.ts
@@ -12,7 +12,9 @@ jest.mock("jspsych", () => ({
   ...jest.requireActual("jspsych"),
   initJsPsych: jest.fn().mockReturnValue({
     finishTrial: jest.fn().mockImplementation(),
-    getCurrentTrial: jest.fn().mockReturnValue({ type: "test-type" }),
+    getCurrentTrial: jest
+      .fn()
+      .mockReturnValue({ type: { info: { name: "test-type" } } }),
   }),
 }));
 
@@ -42,6 +44,7 @@ test("Trial recording", () => {
   const mockRecStop = jest.spyOn(Recorder.prototype, "stop");
   const jsPsych = initJsPsych();
   const trialRec = new Rec.TrialRecordExtension(jsPsych);
+  const getCurrentPluginNameSpy = jest.spyOn(trialRec, "getCurrentPluginName");
 
   trialRec.on_start();
   trialRec.on_load();
@@ -49,7 +52,9 @@ test("Trial recording", () => {
 
   expect(Recorder).toHaveBeenCalledTimes(1);
   expect(mockRecStart).toHaveBeenCalledTimes(1);
+  expect(mockRecStart).toHaveBeenCalledWith(false, "test-type");
   expect(mockRecStop).toHaveBeenCalledTimes(1);
+  expect(getCurrentPluginNameSpy).toHaveBeenCalledTimes(1);
 });
 
 test("Trial recording's initialize does nothing", async () => {

--- a/packages/record/src/index.spec.ts
+++ b/packages/record/src/index.spec.ts
@@ -10,9 +10,10 @@ jest.mock("./recorder");
 jest.mock("@lookit/data");
 jest.mock("jspsych", () => ({
   ...jest.requireActual("jspsych"),
-  initJsPsych: jest
-    .fn()
-    .mockReturnValue({ finishTrial: jest.fn().mockImplementation() }),
+  initJsPsych: jest.fn().mockReturnValue({
+    finishTrial: jest.fn().mockImplementation(),
+    getCurrentTrial: jest.fn().mockReturnValue({ type: "test-type" }),
+  }),
 }));
 
 /**

--- a/packages/record/src/recorder.spec.ts
+++ b/packages/record/src/recorder.spec.ts
@@ -1,4 +1,5 @@
 import Data from "@lookit/data";
+import { LookitWindow } from "@lookit/data/dist/types";
 import Handlebars from "handlebars";
 import { initJsPsych } from "jspsych";
 import play_icon from "../img/play-icon.svg";
@@ -19,6 +20,19 @@ import {
 import Recorder from "./recorder";
 import { CSSWidthHeight } from "./types";
 
+declare const window: LookitWindow;
+
+window.chs = {
+  study: {
+    id: "123",
+  },
+  response: {
+    id: "456",
+  },
+} as typeof window.chs;
+
+let originalDate: DateConstructor;
+
 jest.mock("@lookit/data");
 jest.mock("jspsych", () => ({
   ...jest.requireActual("jspsych"),
@@ -33,6 +47,13 @@ jest.mock("jspsych", () => ({
           clone: jest.fn(),
           getTracks: jest.fn().mockReturnValue([{ stop: jest.fn() }]),
         },
+      }),
+    },
+    data: {
+      getLastTrialData: jest.fn().mockReturnValue({
+        values: jest
+          .fn()
+          .mockReturnValue([{ trial_type: "test-type", trial_index: 0 }]),
       }),
     },
   }),
@@ -68,7 +89,7 @@ test("Recorder start", async () => {
   const jsPsych = initJsPsych();
   const rec = new Recorder(jsPsych);
   const media = jsPsych.pluginAPI.getCameraRecorder();
-  await rec.start("consent");
+  await rec.start(true, "video-consent");
 
   expect(media.addEventListener).toHaveBeenCalledTimes(2);
   expect(media.start).toHaveBeenCalledTimes(1);
@@ -112,7 +133,7 @@ test("Recorder initialize error", () => {
     .fn()
     .mockReturnValue(undefined);
 
-  expect(async () => await rec.start("consent")).rejects.toThrow(
+  expect(async () => await rec.start(true, "video-consent")).rejects.toThrow(
     RecorderInitializeError,
   );
 
@@ -443,4 +464,45 @@ test("Recorder insert record Feed with height/width", () => {
     display,
     Handlebars.compile(recordFeed)(view),
   );
+});
+
+test("Recorder createFileName constructs video file names correctly", () => {
+  const jsPsych = initJsPsych();
+  const rec = new Recorder(jsPsych);
+
+  // Mock Date().getTime() timestamp
+  originalDate = Date;
+  const mockTimestamp = 1634774400000;
+  jest.spyOn(global, "Date").mockImplementation(() => {
+    return new originalDate(mockTimestamp);
+  });
+  // Mock random 3-digit number
+  jest.spyOn(global.Math, "random").mockReturnValue(0.123456789);
+  const rand_digits = Math.floor(Math.random() * 1000);
+
+  const index = jsPsych.data.getLastTrialData().values()[0].trial_index + 1;
+  const trial_type = "test-type";
+
+  // Consent prefix is "consent-videoStream"
+  expect(rec["createFileName"](true, trial_type)).toBe(
+    `consent-videoStream_${window.chs.study.id}_${index.toString()}-${trial_type}_${window.chs.response.id}_${mockTimestamp.toString()}_${rand_digits.toString()}.webm`,
+  );
+
+  // Non-consent prefix is "videoStream"
+  expect(rec["createFileName"](false, trial_type)).toBe(
+    `videoStream_${window.chs.study.id}_${index.toString()}-${trial_type}_${window.chs.response.id}_${mockTimestamp.toString()}_${rand_digits.toString()}.webm`,
+  );
+
+  // Trial index is 0 if there's no value for 'last trial index' (jsPsych data is empty)
+  jsPsych.data.getLastTrialData = jest.fn().mockReturnValueOnce({
+    values: jest.fn().mockReturnValue([]),
+  });
+  expect(rec["createFileName"](false, trial_type)).toBe(
+    `videoStream_${window.chs.study.id}_${0}-${trial_type}_${window.chs.response.id}_${mockTimestamp.toString()}_${rand_digits.toString()}.webm`,
+  );
+
+  // Restore the original Date constructor
+  global.Date = originalDate;
+  // Restore Math.random
+  jest.spyOn(global.Math, "random").mockRestore();
 });

--- a/packages/record/src/start.ts
+++ b/packages/record/src/start.ts
@@ -29,8 +29,10 @@ export default class StartRecordPlugin implements JsPsychPlugin<Info> {
 
   /** Trial function called by jsPsych. */
   public trial() {
-    this.recorder.start("session_video").then(() => {
-      this.jsPsych.finishTrial();
-    });
+    this.recorder
+      .start(false, `${StartRecordPlugin.info.name}-multiframe`)
+      .then(() => {
+        this.jsPsych.finishTrial();
+      });
   }
 }

--- a/packages/record/src/trial.ts
+++ b/packages/record/src/trial.ts
@@ -32,7 +32,7 @@ export default class TrialRecordExtension implements JsPsychExtension {
 
   /** Ran when the trial has loaded. */
   public on_load() {
-    this.recorder?.start("trial_video");
+    this.recorder?.start(false, `${this.jsPsych.getCurrentTrial().type}`);
   }
 
   /**

--- a/packages/record/src/trial.ts
+++ b/packages/record/src/trial.ts
@@ -1,6 +1,7 @@
 import autoBind from "auto-bind";
 import { JsPsych, JsPsychExtension, JsPsychExtensionInfo } from "jspsych";
 import Recorder from "./recorder";
+import { jsPsychPluginWithInfo } from "./types";
 
 /** This extension will allow reasearchers to record trials. */
 export default class TrialRecordExtension implements JsPsychExtension {
@@ -9,6 +10,7 @@ export default class TrialRecordExtension implements JsPsychExtension {
   };
 
   private recorder?: Recorder;
+  private pluginName: string | undefined;
 
   /**
    * Video recording extension.
@@ -32,7 +34,8 @@ export default class TrialRecordExtension implements JsPsychExtension {
 
   /** Ran when the trial has loaded. */
   public on_load() {
-    this.recorder?.start(false, `${this.jsPsych.getCurrentTrial().type}`);
+    this.pluginName = this.getCurrentPluginName();
+    this.recorder?.start(false, `${this.pluginName}`);
   }
 
   /**
@@ -43,5 +46,16 @@ export default class TrialRecordExtension implements JsPsychExtension {
   public on_finish() {
     this.recorder?.stop();
     return {};
+  }
+
+  /**
+   * Gets the plugin name for the trial that is being extended. This is same as
+   * the "trial_type" value that is stored in the data for this trial.
+   *
+   * @returns Plugin name string from the plugin class's info.
+   */
+  private getCurrentPluginName() {
+    const current_plugin_class = this.jsPsych.getCurrentTrial().type;
+    return (current_plugin_class as jsPsychPluginWithInfo).info.name;
   }
 }

--- a/packages/record/src/types.ts
+++ b/packages/record/src/types.ts
@@ -1,3 +1,11 @@
+import { JsPsychPlugin, PluginInfo } from "jspsych";
+import { Class } from "type-fest";
+
+export interface jsPsychPluginWithInfo
+  extends Class<JsPsychPlugin<PluginInfo>> {
+  info: PluginInfo;
+}
+
 /**
  * A valid CSS height/width value, which can be a number, a string containing a
  * number with units, or 'auto'.


### PR DESCRIPTION
This PR updates the video file names in the `record` package so that they match the format used by EFP and expected by the lookit-api and and the AWS S3-Lambda trigger. 

- Consent videos: `consent-videoStream_{study}_{frame_id}_{response}_{timestamp}_{random_digits}.webm`
- Non-consent videos: `videoStream_{study}_{frame_id}_{response}_{timestamp}_{random_digits}.webm`

This naming system requires two arguments from the plugin that calls `recorder.start`: 
1. whether or not this is a consent recording, which is used for the prefix
2. the "trial_type" (plugin name), which is used to create the `frame_id` value

The `frame_id` value is the same one that lookit-jspsych uses in the response `sequence` field, and that's used in the lookit-api to identify trials. The format is: `{trial_index}-{trial_type}`. Trial types are not necessarily unique across the experiment, but the trial indices are.

**Implementation note**

Our previous file naming system used a set of pre-defined strings as an argument in the `recorder.start` method: `"consent" | "session_video" | "trial_video"`. It would be nice to still have a set of pre-defined strings for the new `trial_type` string passed to `recorder.start`. But I don't think that's makes sense now, since our trial recording extension is meant to be used with any jsPsych plugin, so we'd have to maintain a long list of all (currently ~40) jsPsych trial types ("html-button-response", etc.). So this argument is just an unconstrained string. I'm open to suggestions for ways of constraining or validating it.

**TO DO**

As discussed here #36, we would like to give researchers the ability to assign their own unique/meaningful trial IDs, and use these index-type IDs as a fallback. But in the interest of meeting our first MVP, I'm just implementing the index-type solution for now, and we can add the support for researcher-provided trial IDs later.