### PR TITLE
Readthedocs For custom jsPsych trials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Procfile
 site
 .DS_Store
 packages/style/**/*.js
+.python-version

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,22 +8,16 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.12"
+    python: "3.13"
   jobs:
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
     post_install:
-      # Install dependencies with 'docs' dependency group
-      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --no-root --sync
 
 mkdocs:
   configuration: mkdocs.yml
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#     - requirements: docs/requirements.txt

--- a/makefile
+++ b/makefile
@@ -5,7 +5,9 @@ build: poetry
 	poetry run mkdocs build --strict
 
 poetry:
-	poetry install --no-root --sync
+	poetry check
+	poetry self update
+	poetry update --sync
 
 clean:
 	rm -rf ./site $(shell poetry env info -p)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,24 +4,34 @@ repo_url: https://github.com/lookit/lookit-jspsych
 
 nav:
   - Home: index.md
-  - CHS's initJsPsych: lookit-initjspsych/README.md
-  - Data: data/README.md
-  - Record: record/README.md
-  - Surveys: surveys/README.md
-  - Templates: templates/README.md
+  - Other Projects:
+      - Lookit API: https://lookit.readthedocs.io
+      - Ember Lookit Frameplayer: https://lookit.readthedocs.io/projects/frameplayer
+  - Trials:
+      - Record: record/README.md
+      - Surveys: surveys/README.md
+  - Additional:
+      - Data: data/README.md
+      - CHS's initJsPsych: lookit-initjspsych/README.md
+      - Templates: templates/README.md
+
 validation:
   omitted_files: warn
   absolute_links: warn
   unrecognized_links: warn
   anchors: warn
+
 exclude_docs: |
   node_modules
   CHANGELOG.md
   !templates
+
 theme:
   name: readthedocs
+
 plugins:
   - search
   - macros
+
 extra:
   jsPsych: https://www.jspsych.org/v8/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,13 +4,13 @@ repo_url: https://github.com/lookit/lookit-jspsych
 
 nav:
   - Home: index.md
-  - Other Projects:
+  - Related projects:
       - Lookit API: https://lookit.readthedocs.io
       - Ember Lookit Frameplayer: https://lookit.readthedocs.io/projects/frameplayer
-  - Trials:
+  - Plugins and Extensions:
       - Record: record/README.md
       - Surveys: surveys/README.md
-  - Additional:
+  - Developers:
       - Data: data/README.md
       - CHS's initJsPsych: lookit-initjspsych/README.md
       - Templates: templates/README.md

--- a/packages/record/README.md
+++ b/packages/record/README.md
@@ -48,9 +48,9 @@ const jsPsych = initJsPsych({
 });
 ```
 
-Next, create a video configuration trial as described above. Add trial recording
-to the extensions parameter of the trial that needs to be recorded. Any trial
-you design can be recorded by add this extension.
+Next, create a video configuration trial as described above. Then, add the trial
+recoding extension parameter to your trial. By adding this extension, you can
+record any trial you design.
 
 ```javascript
 const trialRec = {
@@ -169,6 +169,12 @@ put "en-US" for the locale. We support the following language codes:
 | Japanese       |        | ja    |
 | Portuguese     | Brazil | pt-BR |
 | Portuguese     |        | pt    |
+
+**`template` [String | "consent_005"]**
+
+Which consent document template to use. If you are setting up a new study, we
+recommend using the most recent (highest number) of these options. Options:
+`consent_005`
 
 **`additional_video_privacy_statement` [String]**
 

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,3 +1,6 @@
 # Templates
 
-This is the beginning of the templates documentation.
+This package contains the translated templates used in other custom CHS jsPsych
+trials. Please see the trial documentation (e.g.
+[Video Consent](../record/README.md#video-consent)) for help using these
+templates.

--- a/poetry.lock
+++ b/poetry.lock
@@ -451,5 +451,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "e27af98fb1de2ddbc32d052b9c1fbd0b843c671b4b33f027377683c92e860975"
+python-versions = "^3.13"
+content-hash = "564c66ffc0988ea9d23ff63c9590bc143995d139f473dd1e4f98f4cb1a8e72b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "lookit-jspsych"
-version = "0.1.0"
+version = "0.0.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.13"
 mkdocs = "^1.6.0"
 mkdocs-macros-plugin = "^1.0.5"
 


### PR DESCRIPTION
# Summary 

Now that the "jsPsych" docs are up on read the docs, I wanted to make a few changes for clarity and simplicity.  Also, I cleaned the "MkDocs" config file of unnecessary comments.