### PR TITLE
readthedocs doesn't support 3.13.  Rollback to 3.12

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.13"
+    python: "3.12"
   jobs:
     post_create_environment:
       # Install poetry

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ build: poetry
 poetry:
 	poetry check
 	poetry self update
-	poetry env use 3.13
+	poetry env use 3.12
 	poetry update --sync
 
 clean:

--- a/poetry.lock
+++ b/poetry.lock
@@ -451,5 +451,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.13"
-content-hash = "564c66ffc0988ea9d23ff63c9590bc143995d139f473dd1e4f98f4cb1a8e72b2"
+python-versions = "^3.12"
+content-hash = "e27af98fb1de2ddbc32d052b9c1fbd0b843c671b4b33f027377683c92e860975"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,9 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.12"
 mkdocs = "^1.6.0"
 mkdocs-macros-plugin = "^1.0.5"
-
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Summary

Whoops!  Readthedocs doesn't support Python 3.13. Moving version back to 3.12. 