### PR TITLE
Move AWS secrets from `.env` to lookit-api and add S3 error handling

### DIFF
--- a/packages/data/rollup.config.mjs
+++ b/packages/data/rollup.config.mjs
@@ -1,5 +1,4 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
-import dotenv from "rollup-plugin-dotenv";
 import { makeRollupConfig } from "../../rollup.mjs";
 
 export default makeRollupConfig("chsData").map((config) => {
@@ -8,8 +7,6 @@ export default makeRollupConfig("chsData").map((config) => {
     plugins: [
       // Resolve node dependencies to be used in a browser.
       nodeResolve({ browser: true, preferBuiltins: false }),
-      // Add support for .env files
-      dotenv(),
       ...config.plugins,
     ],
   };

--- a/packages/data/src/errors.ts
+++ b/packages/data/src/errors.ts
@@ -30,18 +30,46 @@ export class AWSConfigError extends Error {
    * AWS cofiguration error. This could be due to incorrect credentials, bucket
    * name, and/or region.
    *
-   * @param errorMsg - Message property of error object from the AWS response.
+   * @param error - Error object from the AWS response.
    */
-  public constructor(errorMsg: string) {
-    super(`AWS configuration error: ${errorMsg}`);
+  public constructor(error: unknown) {
+    let err_msg = "";
+    if (error instanceof Error) {
+      err_msg = error.message;
+    }
+    super(`AWS configuration error: ${err_msg}`);
     this.name = "AWSConfigError";
   }
 }
+
 /** Error for when URL from Django API is not formatted as expected. */
 export class URLWrongError extends Error {
   /** Throw error when URL is not formatted correctly. */
   public constructor() {
     super("URL is different than expected.");
     this.name = "URLWrongError";
+  }
+}
+
+/** Error for when temporary AWS credentials are not found on the page. */
+export class MissingCredentials extends Error {
+  /** Throw error when AWS credentials are not found. */
+  public constructor() {
+    super("AWS credentials for video uploading not found.");
+    this.name = "MissingCredentials";
+  }
+}
+
+/** Error for when temporary AWS credentials have expired. */
+export class ExpiredCredentials extends Error {
+  /** Throw error when temporary AWS credentials have expired. */
+  public constructor() {
+    super(
+      "The video upload credentials have expired. Please re-start the experiment on the CHS website.",
+    );
+    alert(
+      "Your credentials have expired. Please re-start the experiment on the CHS website.",
+    );
+    this.name = "ExpiredCredentials";
   }
 }

--- a/packages/data/src/lookitS3.spec.ts
+++ b/packages/data/src/lookitS3.spec.ts
@@ -17,6 +17,17 @@ jest.mock("@aws-sdk/client-s3", () => ({
   CompleteMultipartUploadCommand: jest.fn().mockImplementation(),
 }));
 
+// Mock the retrieval of AWS variables passed from lookit-api into the jsPsych study template. The variables are stored in a script element that is retrieved with document.getElementById in the LookitS3 constructor. This mock is currently needed for all tests in this file, but could potentially cause problems if document.getElementById is used for other purposes during these tests.
+beforeEach(() => {
+  Object.assign(document, {
+    getElementById: jest.fn().mockImplementation(() => {
+      return {
+        textContent: '{"JSPSYCH_S3_REGION":"region","JSPSYCH_S3_ACCESS_KEY_ID":"keyId","JSPSYCH_S3_SECRET_ACCESS_KEY":"key","JSPSYCH_S3_BUCKET":"bucket","JSPSYCH_S3_SESSION_TOKEN":"token","JSPSYCH_S3_EXPIRATION":"datestring"}'
+      }
+    })
+  });
+});
+
 afterEach(() => {
   jest.clearAllMocks();
 });

--- a/packages/data/src/lookitS3.spec.ts
+++ b/packages/data/src/lookitS3.spec.ts
@@ -3,7 +3,21 @@ import {
   CreateMultipartUploadCommand,
   UploadPartCommand,
 } from "@aws-sdk/client-s3";
+import { ExpiredCredentials } from "./errors";
 import LookitS3 from "./lookitS3";
+
+/** Mock for the AWS expired token error that can be received from s3.send. */
+class MockExpiredTokenError extends Error {
+  /**
+   * Constructor
+   *
+   * @param message - Error message.
+   */
+  public constructor(message: string) {
+    super(message);
+    this.name = "ExpiredTokenException";
+  }
+}
 
 let mockSendRtn: { UploadId?: string; ETag?: string };
 const largeBlob = new Blob(["x".repeat(LookitS3.minUploadSize + 1)]);
@@ -22,9 +36,10 @@ beforeEach(() => {
   Object.assign(document, {
     getElementById: jest.fn().mockImplementation(() => {
       return {
-        textContent: '{"JSPSYCH_S3_REGION":"region","JSPSYCH_S3_ACCESS_KEY_ID":"keyId","JSPSYCH_S3_SECRET_ACCESS_KEY":"key","JSPSYCH_S3_BUCKET":"bucket","JSPSYCH_S3_SESSION_TOKEN":"token","JSPSYCH_S3_EXPIRATION":"datestring"}'
-      }
-    })
+        textContent:
+          '{"JSPSYCH_S3_REGION":"region","JSPSYCH_S3_ACCESS_KEY_ID":"keyId","JSPSYCH_S3_SECRET_ACCESS_KEY":"key","JSPSYCH_S3_BUCKET":"bucket","JSPSYCH_S3_SESSION_TOKEN":"token","JSPSYCH_S3_EXPIRATION":"datestring"}',
+      };
+    }),
   });
 });
 
@@ -112,4 +127,79 @@ test("Upload in progress", async () => {
   s3.onDataAvailable(largeBlob);
   await s3.completeUpload();
   expect(s3.uploadInProgress).toBe(false);
+});
+
+test("Create upload throws expired credentials error", () => {
+  window.alert = jest.fn();
+  const s3 = new LookitS3("key value");
+
+  // Implement the token expired error for s3.send
+  s3["s3"]["send"] = jest.fn(() => {
+    throw new MockExpiredTokenError("");
+  });
+
+  expect(async () => await s3.createUpload()).rejects.toThrow(
+    ExpiredCredentials,
+  );
+  expect(async () => await s3.createUpload()).rejects.toThrow(
+    "The video upload credentials have expired. Please re-start the experiment on the CHS website.",
+  );
+  expect(window.alert).toHaveBeenCalledTimes(2);
+  expect(window.alert).toHaveBeenCalledWith(
+    "Your credentials have expired. Please re-start the experiment on the CHS website.",
+  );
+});
+
+test("Upload part throws expired credentials error", async () => {
+  window.alert = jest.fn();
+  mockSendRtn = { UploadId: "upload id", ETag: "etag" };
+  const s3 = new LookitS3("key value");
+
+  // Create the upload without errors
+  await s3.createUpload();
+  s3.onDataAvailable(largeBlob);
+
+  // Implement the token expired error for s3.send
+  s3["s3"]["send"] = jest.fn(() => {
+    throw new MockExpiredTokenError("");
+  });
+
+  // completeUpload calls uploadPart
+  expect(async () => {
+    await s3.completeUpload();
+  }).rejects.toThrow(ExpiredCredentials);
+  expect(async () => {
+    await s3.completeUpload();
+  }).rejects.toThrow(
+    "The video upload credentials have expired. Please re-start the experiment on the CHS website.",
+  );
+  expect(window.alert).toHaveBeenCalledTimes(2);
+  expect(window.alert).toHaveBeenCalledWith(
+    "Your credentials have expired. Please re-start the experiment on the CHS website.",
+  );
+});
+
+test("Complete upload throws expired credentials", async () => {
+  mockSendRtn = { UploadId: "upload id", ETag: "etag" };
+  const s3 = new LookitS3("key value");
+  await s3.createUpload();
+
+  // Mock addUploadPartPromise because completeUpload will trigger uploadPart and s3.send for the part, before sending the complete upload command. If we just mock the s3.send error and call completeUpload, the error will always be thrown for uploadPart and the code will never reach the second s3.send command to complete the upload.
+  s3["uploadPart"] = jest.fn().mockImplementation(() => {
+    return Promise.resolve({ PartNumber: 1, ETag: "etag" });
+  });
+
+  // Implement the token expired error for s3.send
+  s3["s3"]["send"] = jest.fn(() => {
+    throw new MockExpiredTokenError("");
+  });
+
+  expect(async () => {
+    await s3.completeUpload();
+  }).rejects.toThrow(ExpiredCredentials);
+  expect(async () => {
+    await s3.completeUpload();
+  }).rejects.toThrow(
+    "The video upload credentials have expired. Please re-start the experiment on the CHS website.",
+  );
 });

--- a/packages/data/src/lookitS3.ts
+++ b/packages/data/src/lookitS3.ts
@@ -179,16 +179,16 @@ class LookitS3 {
   public async completeUpload() {
     this.addUploadPartPromise();
 
-    const input = {
-      Bucket: this.bucket,
-      Key: this.key,
-      MultipartUpload: {
-        Parts: await Promise.all(this.promises),
-      },
-      UploadId: this.uploadId,
-    };
-    const command = new CompleteMultipartUploadCommand(input);
     try {
+      const input = {
+        Bucket: this.bucket,
+        Key: this.key,
+        MultipartUpload: {
+          Parts: await Promise.all(this.promises),
+        },
+        UploadId: this.uploadId,
+      };
+      const command = new CompleteMultipartUploadCommand(input);
       const response = await this.s3.send(command);
       this.complete = true;
       this.logRecordingEvent(`Upload complete: ${response.Location}`);
@@ -196,7 +196,7 @@ class LookitS3 {
       this.logRecordingEvent(
         `Error completing upload ${this.key}.\nError: ${error}`,
       );
-      if (this.awsExpiredToken(error)) {
+      if (this.awsExpiredToken(error) || error instanceof ExpiredCredentials) {
         throw new ExpiredCredentials();
       } else {
         throw error;

--- a/packages/data/src/lookitS3config.spec.ts
+++ b/packages/data/src/lookitS3config.spec.ts
@@ -1,3 +1,4 @@
+import { AWSConfigError } from "./errors";
 import LookitS3 from "./lookitS3";
 
 // This is in a separate file because imports can only be mocked once per file, at the top level (not inside test functions), and the config failure test requires a different mock than the rest of the lookitS3 tests.
@@ -7,8 +8,27 @@ jest.mock("@aws-sdk/client-s3", () => ({
   }),
 }));
 
+// Mock the retrieval of AWS variables passed from lookit-api into the jsPsych study template. The variables are stored in a script element that is retrieved with document.getElementById  in the LookitS3 constructor. This mock is currently needed for all tests in this file, but could potentially cause problems if document.getElementById is used for other purposes during these tests.
+beforeEach(() => {
+  Object.assign(document, {
+    getElementById: jest.fn().mockImplementation(() => {
+      return {
+        textContent:
+          '{"JSPSYCH_S3_REGION":"region","JSPSYCH_S3_ACCESS_KEY_ID":"keyId","JSPSYCH_S3_SECRET_ACCESS_KEY":"key","JSPSYCH_S3_BUCKET":"bucket","JSPSYCH_S3_SESSION_TOKEN":"token","JSPSYCH_S3_EXPIRATION":"datestring"}',
+      };
+    }),
+  });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 test.only("Lookit S3 constructor throws error when S3 Client initialization fails", () => {
   expect(() => {
     new LookitS3("key value");
-  }).toThrow();
+  }).toThrow(AWSConfigError);
+  expect(() => {
+    new LookitS3("key value");
+  }).toThrow("AWS configuration error: Error");
 });

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -140,3 +140,12 @@ export interface LookitWindow extends Window {
     sessionRecorder: unknown;
   };
 }
+
+export interface awsVars {
+  JSPSYCH_S3_REGION: string;
+  JSPSYCH_S3_ACCESS_KEY_ID: string;
+  JSPSYCH_S3_SECRET_ACCESS_KEY: string;
+  JSPSYCH_S3_BUCKET: string;
+  JSPSYCH_S3_SESSION_TOKEN: string;
+  JSPSYCH_S3_EXPIRATION: string;
+}


### PR DESCRIPTION
This PR moves the AWS S3 secrets for jsPsych video uploading out of an environment variable in the `data` package. They'll now be available to the `data` package via the `lookit-api` (including in local development).

The AWS secrets have also been changed to temporary credentials, so this adds checks and error handling for an 'expired token' error that can occur in response to any request sent to AWS S3.

**List of changes**

- Moves the AWS variables from a `data` package `.env` file to the `lookit-api`. This means that the variables are obtained from the document at runtime, and we are no longer using the `dotenv` package or `process.env` in `data`.
- Adds a new `MissingCredentials` error for when the AWS credentials are not found on the page.
- Adds a new `ExpiredCredentials` error for when the AWS credentials have expired.
- Adds tests for the new errors and error handling.

**Important**

This change to lookit-jspsych must be made in conjunction with the corresponding change in `lookit-api`, which adds the AWS secret temporary credentials into the jsPsych study template.