### PR TITLE
Production dotenv

### DIFF
--- a/.changeset/mean-llamas-cheat.md
+++ b/.changeset/mean-llamas-cheat.md
@@ -1,0 +1,7 @@
+---
+"@lookit/templates": patch
+"@lookit/record": patch
+"@lookit/data": patch
+---
+
+Generate environment file before production build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: ["18.x", "20.x"]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,12 @@ jobs:
 
       - name: Install NPM dependencies
         run: npm ci
+
+      - name: Create environment file
+        run: printenv > .env
+        env:
+          DEBUG: "false"
+          LOCAL_DOWNLOAD: "false"
 
       - name: Build packages
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -95,15 +95,21 @@ npm i @jspsych/config -w @lookit/<name of new package>
 
 ## Build all packages
 
-We can use npm workspaces to build all packages.
+First, create a `.env` file at the root of the monorepo. It can contain the
+following for a successful local development build.
 
-First, install dependencies:
+```
+DEBUG=true
+LOCAL_DOWNLOAD=true
+```
+
+Next, we can use npm to install dependencies.
 
 ```
 npm ci
 ```
 
-Build all packages:
+Then, build all packages.
 
 ```
 npm run build

--- a/packages/data/rollup.config.mjs
+++ b/packages/data/rollup.config.mjs
@@ -9,7 +9,7 @@ export default makeRollupConfig("chsData").map((config) => {
       // Resolve node dependencies to be used in a browser.
       nodeResolve({ browser: true, preferBuiltins: false }),
       // Add support for .env files
-      dotenv(),
+      dotenv({ cwd: "../../" }),
       ...config.plugins,
     ],
   };

--- a/packages/record/rollup.config.mjs
+++ b/packages/record/rollup.config.mjs
@@ -11,7 +11,7 @@ export default makeRollupConfig("chsRecord").map((config) => {
     plugins: [
       ...config.plugins,
       // Add support for .env files
-      dotenv(),
+      dotenv({ cwd: "../../" }),
       // Add support to import yaml and handlebars files as strings
       importAsString({
         include: ["**/*.yaml", "**/*.hbs"],

--- a/packages/templates/rollup.config.mjs
+++ b/packages/templates/rollup.config.mjs
@@ -9,7 +9,7 @@ export default makeRollupConfig("chsTemplates").map((config) => {
     plugins: [
       ...config.plugins,
       // Add support for .env files
-      dotenv(),
+      dotenv({ cwd: "../../" }),
       // Add support to import yaml and handlebars files as strings
       importAsString({
         include: ["**/*.yaml", "**/*.hbs"],


### PR DESCRIPTION
# Summary

The production build didn't include environment variables. Where a value, such as DEBUG, could be "undefined," Rollupjs would leave it as "process.env.DEBUG." This throws an error in the browser. To fix this issue, we generated an environment file before the production build. 

Additionally, I configured Rollupjs to look for the environment file in a central location at the root of the mono repo. 