### PR TITLE
Add default for optional `additional_segments` parameter in video consent

### DIFF
--- a/.changeset/smart-books-scream.md
+++ b/.changeset/smart-books-scream.md
@@ -1,0 +1,6 @@
+---
+"@lookit/record": patch
+---
+
+Add missing default value for video consent "additional_segments" parameter,
+which was causing an error when this optional parameter was omitted (#84).

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -55,8 +55,8 @@ const info = <const>{
         text: {
           type: ParameterType.STRING,
           default: "",
-        }
-      }
+        },
+      },
     },
     prompt_all_adults: { type: ParameterType.BOOL, default: false },
     prompt_only_adults: { type: ParameterType.BOOL, default: false },

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -46,16 +46,17 @@ const info = <const>{
     additional_segments: {
       type: ParameterType.COMPLEX,
       array: true,
+      default: [],
       nested: {
         title: {
           type: ParameterType.STRING,
           default: "",
         },
-      },
-      text: {
-        type: ParameterType.STRING,
-        default: "",
-      },
+        text: {
+          type: ParameterType.STRING,
+          default: "",
+        }
+      }
     },
     prompt_all_adults: { type: ParameterType.BOOL, default: false },
     prompt_only_adults: { type: ParameterType.BOOL, default: false },


### PR DESCRIPTION
Fixes #84

This PR adds a default value (empty array) for the `additional_segments` parameter in the video consent plugin. The missing default value was causing jsPsych to produce a runtime error when this optional parameter was omitted from the trial configuration.

This also moves the 'text' property in the parameter info object into the additional segments `nested` object, which is what defines the structure of the "COMPLEX" (object) parameter type. In this case, the `additional_segments` parameter can be an array of objects, where each object can have a "title" (string) and "text" (string) property.

**Note**

The default value for this parameter could also be: `[{title: "", text: ""}]`. I'm not sure whether it matters?

**Screenshots**

After this fix, the video consent plugin runs without anything specified for the `additional_segments` parameter.

![Screenshot 2024-10-28 at 3 56 10 PM](https://github.com/user-attachments/assets/5c8bd8d9-aac2-45a9-bf35-e650ff8b6a1f)

It also correctly renders an `additional_segments` parameter if one is defined ("US Patriot Act" section).

![Screenshot 2024-10-28 at 3 55 35 PM](https://github.com/user-attachments/assets/dde77e16-7bf0-476f-be75-4ce82490b52f)