### PR TITLE
Bump initjspsych version

### DIFF
--- a/.changeset/plenty-carpets-yell.md
+++ b/.changeset/plenty-carpets-yell.md
@@ -1,0 +1,5 @@
+---
+"@lookit/lookit-initjspsych": patch
+---
+
+Bump version to get around incorrectly versioned releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -20787,7 +20787,7 @@
     },
     "packages/data": {
       "name": "@lookit/data",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "3.645.0",
@@ -20805,7 +20805,7 @@
     },
     "packages/lookit-initjspsych": {
       "name": "@lookit/lookit-initjspsych",
-      "version": "0.0.5",
+      "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
         "@jspsych/config": "^2.0.0"
@@ -20815,13 +20815,13 @@
         "@rollup/rollup-linux-x64-gnu": "^4.14.1"
       },
       "peerDependencies": {
-        "@lookit/data": "^0.0.5",
+        "@lookit/data": "^0.1.0",
         "jspsych": "^8.0.2"
       }
     },
     "packages/record": {
       "name": "@lookit/record",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "auto-bind": "^5.0.1"
@@ -20844,8 +20844,8 @@
         "typescript": "^5.6.2"
       },
       "peerDependencies": {
-        "@lookit/data": "^0.0.5",
-        "@lookit/templates": "^0.0.2",
+        "@lookit/data": "^0.1.0",
+        "@lookit/templates": "^1.0.0",
         "jspsych": "^8.0.2"
       }
     },
@@ -20907,12 +20907,12 @@
     },
     "packages/style": {
       "name": "@lookit/style",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "ISC",
       "devDependencies": {
         "@jspsych/config": "^2.0.0",
-        "@lookit/record": "^0.0.5",
-        "@lookit/surveys": "^0.0.5",
+        "@lookit/record": "^1.0.0",
+        "@lookit/surveys": "^1.0.0",
         "rollup-plugin-scss": "^4.0.0",
         "sass": "^1.78.0",
         "trash-cli": "^5.0.0"
@@ -21045,7 +21045,7 @@
     },
     "packages/surveys": {
       "name": "@lookit/surveys",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@jspsych/plugin-survey": "^2.0.0",
@@ -21058,13 +21058,13 @@
         "@types/dompurify": "^3.0.5"
       },
       "peerDependencies": {
-        "@lookit/data": "^0.0.5",
+        "@lookit/data": "^0.1.0",
         "jspsych": "^8.0.2"
       }
     },
     "packages/templates": {
       "name": "@lookit/templates",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
         "@jspsych/config": "^2.0.0",
@@ -21073,7 +21073,7 @@
         "rollup-plugin-polyfill-node": "^0.13.0"
       },
       "peerDependencies": {
-        "@lookit/data": "^0.0.5",
+        "@lookit/data": "^0.1.0",
         "jspsych": "^8.0.2"
       }
     }

--- a/packages/lookit-initjspsych/package.json
+++ b/packages/lookit-initjspsych/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lookit/lookit-initjspsych",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "description": "This package overloads jsPsych's init function.",
   "homepage": "https://github.com/lookit/lookit-jspsych#readme",
   "bugs": {


### PR DESCRIPTION
# Summary 
NPM has already seen v1.0.0 of lookit-initjspsych and versions up to 1.0.5. NPM won't let you re-publish a package with a known version.  This PR will move this package's version to 1.0.6.  