### PR TITLE
Add `locale` to `survey` docs

### DIFF
--- a/.changeset/purple-phones-count.md
+++ b/.changeset/purple-phones-count.md
@@ -1,0 +1,6 @@
+---
+"@lookit/surveys": patch
+"@lookit/record": patch
+---
+
+Documentation update: add/modify locale parameter documentation.

--- a/packages/record/README.md
+++ b/packages/record/README.md
@@ -9,8 +9,8 @@ either a single trial or multiple trials.
 
 Optional parameter to set a two-letter language code for translation. In some
 cases, a regional code will have to be provided as well. For example, we
-currently support english only from the US region. Therefore, to get the US
-english translation you would put "en-US" for the locale. We support the
+currently support English only from the US region. Therefore, to get the US
+English translation you would put "en-US" for the locale. We support the
 following language codes:
 
 | Language       | Region | Code  |

--- a/packages/surveys/README.md
+++ b/packages/surveys/README.md
@@ -4,6 +4,28 @@ This package contains the custom surveys provided by CHS for jsPsych studies.
 These surveys are built off of the very nice [jsPsych
 Survey plugin]({{ jsPsych }}plugins/survey/).
 
+## Parameters available in all plugins
+
+**`locale` [String | "en-us"]**
+
+Optional parameter to set a two-letter language code for translation. In some
+cases, a regional code will have to be provided as well. For example, we
+currently support English only from the US region. Therefore, to get the US
+English translation you would put "en-US" for the locale. We support the
+following language codes:
+
+| Language       | Region | Code  |
+| -------------- | ------ | ----- |
+| Basque         |        | eu    |
+| Dutch, Flemish |        | nl    |
+| English        | U.S.A. | en-US |
+| French         |        | fr    |
+| Hungarian      |        | hu    |
+| Italian        |        | it    |
+| Japanese       |        | ja    |
+| Portuguese     | Brazil | pt-BR |
+| Portuguese     |        | pt    |
+
 ## Consent Survey
 
 The Consent Survey will will give you two things out of the box:


### PR DESCRIPTION
This PR adds the `locale` parameter to the `survey` package docs, and makes a minor change to the `record` docs.

The `locale` parameter was added to the `survey` plugins here in #97 and #98 but those PRs do not include the docs update.

Merging this without review.