### PR TITLE
Fix the 'missing locale' error in the consentSurvey plugin

### DIFF
--- a/.changeset/shiny-walls-refuse.md
+++ b/.changeset/shiny-walls-refuse.md
@@ -1,0 +1,6 @@
+---
+"@lookit/surveys": patch
+---
+
+Fix "missing locale" error when the optional locale parameter is not specified
+in a consent-survey plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20803,7 +20803,7 @@
     },
     "packages/record": {
       "name": "@lookit/record",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "auto-bind": "^5.0.1"
@@ -20822,7 +20822,7 @@
       },
       "peerDependencies": {
         "@lookit/data": "^0.1.0",
-        "@lookit/templates": "^1.0.0",
+        "@lookit/templates": "^1.1.0",
         "jspsych": "^8.0.2"
       }
     },
@@ -20864,12 +20864,12 @@
     },
     "packages/style": {
       "name": "@lookit/style",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "devDependencies": {
         "@jspsych/config": "^2.0.0",
-        "@lookit/record": "^1.0.0",
-        "@lookit/surveys": "^1.0.0",
+        "@lookit/record": "^2.0.0",
+        "@lookit/surveys": "^2.0.0",
         "rollup-plugin-scss": "^4.0.0",
         "sass": "^1.78.0",
         "trash-cli": "^5.0.0"
@@ -21002,7 +21002,7 @@
     },
     "packages/surveys": {
       "name": "@lookit/surveys",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@jspsych/plugin-survey": "^2.0.0",
@@ -21015,13 +21015,13 @@
       },
       "peerDependencies": {
         "@lookit/data": "^0.1.0",
-        "@lookit/templates": "^1.0.0",
+        "@lookit/templates": "^1.1.0",
         "jspsych": "^8.0.2"
       }
     },
     "packages/templates": {
       "name": "@lookit/templates",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@jspsych/config": "^2.0.0",

--- a/packages/surveys/src/consentSurvey.ts
+++ b/packages/surveys/src/consentSurvey.ts
@@ -18,7 +18,7 @@ export type Trial = TrialType<Info>;
 
 /** Consent Survey plugin extends jsPsych's Survey Plugin. */
 export class ConsentSurveyPlugin extends SurveyPlugin {
-  public static readonly info = SurveyPlugin.info;
+  public static readonly info = info;
   /**
    * Custom consent survey function adds functionality before creating a survey
    * based on the user-defined survey JSON/function.


### PR DESCRIPTION
This PR fixes the 'missing locale' error that is thrown when running a consent survey trial with no `locale` parameter value. This parameter should be optional, and jsPsych should use the default value in the plugin's parameter info if no value is set by the user.

The problem was that our ConsentSurveyPlugin class was still using the info from the jsPsych `survey` plugin, which we are extending with this plugin. 