### PR TITLE
Exit URL fix

### DIFF
--- a/.changeset/itchy-books-judge.md
+++ b/.changeset/itchy-books-judge.md
@@ -1,0 +1,5 @@
+---
+"@lookit/lookit-initjspsych": patch
+---
+
+Fixes an error that is thrown when the experiment has only one trial.

--- a/.changeset/thin-oranges-collect.md
+++ b/.changeset/thin-oranges-collect.md
@@ -1,0 +1,5 @@
+---
+"@lookit/lookit-initjspsych": patch
+---
+
+Fix the exit URL interupting final Response patch

--- a/package-lock.json
+++ b/package-lock.json
@@ -21002,7 +21002,7 @@
     },
     "packages/surveys": {
       "name": "@lookit/surveys",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@jspsych/plugin-survey": "^2.0.0",

--- a/packages/lookit-initjspsych/src/utils.spec.ts
+++ b/packages/lookit-initjspsych/src/utils.spec.ts
@@ -1,8 +1,7 @@
 import { DataCollection } from "jspsych";
 
 import { Child, JsPsychExpData, Study } from "@lookit/data/dist/types";
-import { nth } from "./errors";
-import { Timeline } from "./types";
+import { nth, SequenceExpDataError } from "./errors";
 import { on_data_update, on_finish } from "./utils";
 
 delete global.window.location;
@@ -104,48 +103,6 @@ test("jsPsych's on_finish", async () => {
   expect(Request).toHaveBeenCalledTimes(2);
 });
 
-test("Is an error thrown when experiment data is empty?", () => {
-  const exp_data: Timeline[] = [];
-  const jsonData = {
-    data: {
-      attributes: { exp_data, sequence: ["0-value"] },
-    },
-  };
-  const data = {
-    /**
-     * Mocked jsPsych Data Collection.
-     *
-     * @returns Exp data.
-     */
-    values: () => exp_data,
-  } as DataCollection;
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
-
-  const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
-  global.Request = jest.fn();
-
-  Object.assign(window, {
-    chs: {
-      study: { attributes: { exit_url: "exit url" } } as Study,
-      child: {} as Child,
-      pastSessions: {} as Response[],
-    },
-  });
-
-  expect(async () => {
-    await on_finish("some id", userFn)(data);
-  }).rejects.toThrow("Experiment sequence or data missing.");
-});
-
 test("Is an error thrown when experiment sequence is undefined?", () => {
   const exp_data = [{ key: "value" }];
   const jsonData = {
@@ -185,7 +142,7 @@ test("Is an error thrown when experiment sequence is undefined?", () => {
 
   expect(async () => {
     await on_finish("some id", userFn)(data);
-  }).rejects.toThrow("Experiment sequence or data missing.");
+  }).rejects.toThrow(SequenceExpDataError);
 });
 
 test("Ordinal format of numbers", () => {

--- a/packages/lookit-initjspsych/src/utils.ts
+++ b/packages/lookit-initjspsych/src/utils.ts
@@ -74,13 +74,12 @@ export const on_finish = (
       userFunc(data);
     }
 
-    await Api.finish();
     await Api.updateResponse(responseUuid, {
       exp_data,
       sequence: [...sequence, `${last_exp.trial_index}-${last_exp.trial_type}`],
       completed: true,
-    });
-
-    exit_url && window.location.replace(exit_url);
+    })
+      .then(() => Api.finish())
+      .then(() => exit_url && window.location.replace(exit_url));
   };
 };

--- a/packages/lookit-initjspsych/src/utils.ts
+++ b/packages/lookit-initjspsych/src/utils.ts
@@ -62,7 +62,7 @@ export const on_finish = (
 
     const exp_data: JsPsychExpData[] = data.values();
 
-    if (!sequence || sequence.length === 0 || exp_data.length === 0) {
+    if (!sequence || (sequence.length === 0 && exp_data.length === 0)) {
       throw new SequenceExpDataError();
     }
 

--- a/packages/lookit-initjspsych/src/utils.ts
+++ b/packages/lookit-initjspsych/src/utils.ts
@@ -62,7 +62,7 @@ export const on_finish = (
 
     const exp_data: JsPsychExpData[] = data.values();
 
-    if (!sequence || (sequence.length === 0 && exp_data.length === 0)) {
+    if (!Array.isArray(sequence)) {
       throw new SequenceExpDataError();
     }
 


### PR DESCRIPTION
# Summary

The exit URL was still interrupting the final Response update.  This PR uses Promise's "Then"s to make the calls happen in order. 