### PR TITLE
Add docs section links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,3 +35,7 @@ plugins:
 
 extra:
   jsPsych: https://www.jspsych.org/v8/
+
+markdown_extensions:
+  - toc:
+      permalink: True


### PR DESCRIPTION
This PR adds a markdown extension that adds permanent links to all of the sections in docs pages. E.g. see screenshot below - hovering over "Parameters" produces a link icon, and clicking on it gives you the link to that section.

![Screenshot 2024-11-12 at 1 42 13 PM](https://github.com/user-attachments/assets/0e9dbea3-5977-4d53-8abf-b28d357fcdbc)
