### PR TITLE
Fix video recording playback issues

### DIFF
--- a/.changeset/calm-tomatoes-warn.md
+++ b/.changeset/calm-tomatoes-warn.md
@@ -1,0 +1,6 @@
+---
+"@lookit/record": patch
+---
+
+Fix recording playback issues, which were caused by not specifying codecs in the
+recorder mime type.

--- a/packages/record/src/recorder.spec.ts
+++ b/packages/record/src/recorder.spec.ts
@@ -556,15 +556,6 @@ test("Initializing a new recorder gets the mime type from the initialization", (
   expect(jsPsych.pluginAPI.getCameraRecorder).toHaveBeenCalledTimes(4);
   expect(rec_2["mimeType"]).toBe("video/webm;codecs=vp8,opus");
 
-  // Initialize with av1
-  recorder_options = {
-    mimeType: "video/webm;codecs=av1,opus",
-  };
-  jsPsych.pluginAPI.initializeCameraRecorder(stream, recorder_options);
-  const rec_3 = new Recorder(jsPsych);
-  expect(jsPsych.pluginAPI.getCameraRecorder).toHaveBeenCalledTimes(6);
-  expect(rec_3["mimeType"]).toBe("video/webm;codecs=av1,opus");
-
   jsPsych.pluginAPI.initializeCameraRecorder = originalInitializeCameraRecorder;
 });
 

--- a/packages/record/src/recorder.ts
+++ b/packages/record/src/recorder.ts
@@ -34,6 +34,7 @@ export default class Recorder {
   private filename?: string;
   private stopPromise?: Promise<void>;
   private webcam_element_id = "lookit-jspsych-webcam";
+  private mimeType = "video/webm";
 
   private streamClone: MediaStream;
 
@@ -45,6 +46,8 @@ export default class Recorder {
   public constructor(private jsPsych: JsPsych) {
     this.streamClone = this.stream.clone();
     autoBind(this);
+    // Use the class instance's mimeType default as a fallback if we can't get the mime type from the initialized jsPsych recorder.
+    this.mimeType = this.recorder?.mimeType || this.mimeType;
   }
 
   /**
@@ -99,7 +102,11 @@ export default class Recorder {
    * @param opts - Media recorder options to use when setting up the recorder.
    */
   public initializeRecorder(stream: MediaStream, opts?: MediaRecorderOptions) {
-    this.jsPsych.pluginAPI.initializeCameraRecorder(stream, opts);
+    const recorder_options: MediaRecorderOptions = {
+      ...opts,
+      mimeType: this.mimeType,
+    };
+    this.jsPsych.pluginAPI.initializeCameraRecorder(stream, recorder_options);
   }
 
   /** Reset the recorder to be used again. */

--- a/packages/record/src/videoConfig.spec.ts
+++ b/packages/record/src/videoConfig.spec.ts
@@ -1196,43 +1196,18 @@ test("Video config getCompatibleMimeType gets correct mime type or null", () => 
   const mime_type_2 = video_config["getCompatibleMimeType"]();
   expect(mime_type_2).toBe("video/webm;codecs=vp8,opus");
 
-  // 3. only supports av1,opus
+  // 3. supports vp9,opus and vp8,opus, should use the former
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isTypeSupportedSpy.mockImplementation((type) => {
-    if (type == "video/webm;codecs=av1,opus") {
-      return true;
-    } else {
-      return false;
-    }
+    return true;
   });
   const mime_type_3 = video_config["getCompatibleMimeType"]();
-  expect(mime_type_3).toBe("video/webm;codecs=av1,opus");
+  expect(mime_type_3).toBe("video/webm;codecs=vp9,opus");
 
-  // 4. supports vp9,opus and av1,opus, should use the former
-  isTypeSupportedSpy.mockImplementation((type) => {
-    if (type == "video/webm;codecs=vp8,opus") {
-      return false;
-    } else {
-      return true;
-    }
-  });
-  const mime_type_4 = video_config["getCompatibleMimeType"]();
-  expect(mime_type_4).toBe("video/webm;codecs=vp9,opus");
-
-  // 5. supports vp8,opus and av1,opus, should use the former
-  isTypeSupportedSpy.mockImplementation((type) => {
-    if (type == "video/webm;codecs=vp9,opus") {
-      return false;
-    } else {
-      return true;
-    }
-  });
-  const mime_type_5 = video_config["getCompatibleMimeType"]();
-  expect(mime_type_5).toBe("video/webm;codecs=vp8,opus");
-
-  // 6. none supported, should return null
+  // 4. none supported, should return null
   isTypeSupportedSpy.mockImplementation(() => {
     return false;
   });
-  const mime_type_6 = video_config["getCompatibleMimeType"]();
-  expect(mime_type_6).toBeNull();
+  const mime_type_4 = video_config["getCompatibleMimeType"]();
+  expect(mime_type_4).toBeNull();
 });

--- a/packages/record/src/videoConfig.ts
+++ b/packages/record/src/videoConfig.ts
@@ -678,13 +678,15 @@ export default class VideoConfigPlugin implements JsPsychPlugin<Info> {
    * initialization function (jsPsych.pluginAPI.initializeCameraRecorder). If
    * none of these types is supported, the function returns null.
    *
+   * Note: we will likely need to continuously update the mime_types list as new
+   * formats become supported, we support other browsers/versions, etc.
+   *
    * @returns Mime type string, or null (if none from the array are supported).
    */
   private getCompatibleMimeType() {
     const mime_types = [
       "video/webm;codecs=vp9,opus",
       "video/webm;codecs=vp8,opus",
-      "video/webm;codecs=av1,opus",
     ];
     let mime_type_index = 0;
     while (mime_type_index < mime_types.length) {


### PR DESCRIPTION
Fixes #126

This fixes a problem with video recordings not playing in some browsers. The problem is due to initializing a recorder without specifying the codecs (we had the same thing happen in EFP: https://github.com/lookit/ember-lookit-frameplayer/pull/365). To fix this, we just need to specify the mimeType codecs value as part of the recording options when the recorder is initialized. This PR does the following:

- In the video config plugin, adds a `getCompatibleMimeType` method to check mime type compatibility and get the first compatible type from the list. This mime type string must be specified when the plugin initializes the jsPsych recorder via `jsPsych.pluginAPI.initializeCameraRecorder`.
- In the recorder class, gets the mime type value from the existing recorder and stores it. This is needed in case the recorder class re-initializes the jsPsych recorder (via its `initializeRecorder` method and `jsPsych.pluginAPI.initializeCameraRecorder`). 
- Sets a default/fallback mime type of "video/webm".
- Adds tests.