### PR TITLE
Fix timeline node error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6994,7 +6994,6 @@
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
       "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -19778,7 +19777,6 @@
       "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.3.0.tgz",
       "integrity": "sha512-brwCGe+DN9DqZrAQVNj1Tct1Lody6GrYL/7uei5wfjeQdacFyFd2h/51LNlOoBMzIKMS9xohuL4+wlF/z1g/xg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "seedrandom": "^3.0.5"
       }
@@ -20750,8 +20748,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23755,12 +23755,38 @@
       "name": "@lookit/lookit-initjspsych",
       "version": "2.0.0",
       "license": "ISC",
+      "dependencies": {
+        "jspsych": "8.0.3"
+      },
       "devDependencies": {
         "@jspsych/config": "^3.0.1"
       },
       "peerDependencies": {
-        "@lookit/data": "^0.2.0",
-        "jspsych": "^8.0.3"
+        "@lookit/data": "^0.2.0"
+      }
+    },
+    "packages/lookit-initjspsych/node_modules/jspsych": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/jspsych/-/jspsych-8.0.3.tgz",
+      "integrity": "sha512-O7cj/2jHkGI2nqK8qDVKdPrzP5XkCCRry7uYRJe+EtkxI3Y11qCW4wAwsgJyh+yO8UlgpNB/FsP/e0UIVARTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "auto-bind": "^4.0.0",
+        "random-words": "^1.1.1",
+        "seedrandom": "^3.0.5",
+        "type-fest": "^2.9.0"
+      }
+    },
+    "packages/lookit-initjspsych/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/record": {

--- a/packages/lookit-initjspsych/fixtures/TestPlugin.ts
+++ b/packages/lookit-initjspsych/fixtures/TestPlugin.ts
@@ -1,0 +1,157 @@
+import { flushPromises } from "@jspsych/test-utils";
+import { JsPsych, TrialType } from "jspsych";
+
+import { ParameterInfos } from "jspsych/src/modules/plugins";
+import {
+  SimulationMode,
+  SimulationOptions,
+  TrialResult,
+} from "jspsych/src/timeline";
+import { PromiseWrapper } from "jspsych/src/timeline/util";
+import { ChsJsPsychPlugin } from "../src/types";
+
+// Test Plugin copied from jspsych/tests/TestPlugin and modified to include chsData() as a static method.
+// TO DO: Submit PR for exposing the TestPlugin via jsPsych so that we can import it.
+
+export const testPluginInfo = <const>{
+  name: "test",
+  version: "0.0.1",
+  parameters: {},
+  data: {},
+};
+
+/** Test plugin */
+class TestPlugin implements ChsJsPsychPlugin<typeof testPluginInfo> {
+  public static info = testPluginInfo;
+
+  /**
+   * Set parameter info for this plugin.
+   *
+   * @param parameters - Parameters to be used for the test plugin info.
+   */
+  public static setParameterInfos(parameters: ParameterInfos) {
+    TestPlugin.info = { ...testPluginInfo, parameters };
+  }
+
+  /** Resets the plugin info. */
+  public static resetPluginInfo() {
+    TestPlugin.info = testPluginInfo;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public static defaultTrialResult: Record<string, any> = { my: "result" };
+
+  private static finishTrialMode: "immediate" | "manual" = "immediate";
+
+  /**
+   * Disables immediate finishing of the `trial` method of all `TestPlugin`
+   * instances. Instead, any running trial can be finished by invoking
+   * `TestPlugin.finishTrial()`.
+   */
+  public static setManualFinishTrialMode() {
+    TestPlugin.finishTrialMode = "manual";
+  }
+
+  /**
+   * Makes the `trial` method of all instances of `TestPlugin` finish
+   * immediately and allows to manually finish the trial by invoking
+   * `TestPlugin.finishTrial()` instead.
+   */
+  public static setImmediateFinishTrialMode() {
+    TestPlugin.finishTrialMode = "immediate";
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static trialPromise = new PromiseWrapper<Record<string, any>>();
+
+  /**
+   * Resolves the promise returned by `trial()` with the provided `result` or
+   * `TestPlugin.defaultTrialResult` if no `result` object was passed.
+   *
+   * @param result - Object with key/values to be added as the the data.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public static async finishTrial(result?: Record<string, any>) {
+    TestPlugin.trialPromise.resolve(result ?? TestPlugin.defaultTrialResult);
+    await flushPromises();
+  }
+
+  /**
+   * Provides a default trial implementation.
+   *
+   * @param display_element - HTML element that holds the jsPsych experiment
+   * @param trial - Trial
+   * @param on_load - On load function
+   * @returns Promise that resolves with trial result.
+   */
+  public static defaultTrialImplementation(
+    display_element: HTMLElement,
+    trial: TrialType<typeof testPluginInfo>,
+    on_load: () => void,
+  ): void | Promise<TrialResult | void> {
+    on_load();
+    if (TestPlugin.finishTrialMode === "immediate") {
+      return Promise.resolve(TestPlugin.defaultTrialResult);
+    }
+    return TestPlugin.trialPromise.get();
+  }
+
+  public static trial = TestPlugin.defaultTrialImplementation;
+
+  /**
+   * Default implementation of the plugin's simulate function.
+   *
+   * @param trial - Trial object
+   * @param simulation_mode - "visual" or "data-only"
+   * @param simulation_options - Object with options for data, mode, and
+   *   simulate
+   * @param on_load - On load callback function
+   * @returns Default trial implementation
+   */
+  public static defaultSimulateImplementation(
+    trial: TrialType<typeof testPluginInfo>,
+    simulation_mode: SimulationMode,
+    simulation_options: SimulationOptions,
+    on_load?: () => void,
+  ): void | Promise<void | TrialResult> {
+    return TestPlugin.defaultTrialImplementation(
+      document.createElement("div"),
+      trial,
+      on_load as () => void,
+    );
+  }
+
+  public static simulate = TestPlugin.defaultSimulateImplementation;
+
+  /** Resets all static properties including function implementations */
+  public static reset() {
+    TestPlugin.defaultTrialResult = { my: "result" };
+    TestPlugin.trial = TestPlugin.defaultTrialImplementation;
+    TestPlugin.simulate = TestPlugin.defaultSimulateImplementation;
+    TestPlugin.resetPluginInfo();
+    TestPlugin.setImmediateFinishTrialMode();
+  }
+
+  /**
+   * Test plugin constructor.
+   *
+   * @param jsPsych - JsPsych instance
+   */
+  public constructor(private jsPsych: JsPsych) {}
+
+  public trial = jest.fn(TestPlugin.trial);
+  public simulate = jest.fn(TestPlugin.simulate);
+
+  /**
+   * Method added to CHS jsPsych plugins for automatically adding custom data to
+   * response.
+   *
+   * @returns Data object added by TestPlugin. This is added to the data from
+   *   all TestPlugin trials (via lookitInitJsPsych).
+   */
+  public static chsData() {
+    return { chs_type: "test" };
+  }
+}
+
+export default TestPlugin;

--- a/packages/lookit-initjspsych/jest.config.cjs
+++ b/packages/lookit-initjspsych/jest.config.cjs
@@ -2,6 +2,10 @@ const config = require("../../jest.cjs").makePackageConfig();
 module.exports = {
   ...config,
   coveragePathIgnorePatterns: ["fixtures"],
+  transformIgnorePatterns: ["node_modules/(?!jspsych)"],
+  moduleNameMapper: {
+    "^jspsych/src/(.*)$": "<rootDir>/node_modules/jspsych/src/$1",
+  },
   testEnvironmentOptions: {
     ...config.testEnvironmentOptions,
     url: "https://localhost:8000/exp/studies/j/1647e101-282a-4fde-a32b-4f493d14f57e/8a2b2f04-63eb-485a-8e55-7b9362368f19/",

--- a/packages/lookit-initjspsych/jest.config.cjs
+++ b/packages/lookit-initjspsych/jest.config.cjs
@@ -1,6 +1,7 @@
 const config = require("../../jest.cjs").makePackageConfig();
 module.exports = {
   ...config,
+  coveragePathIgnorePatterns: ["fixtures"],
   testEnvironmentOptions: {
     ...config.testEnvironmentOptions,
     url: "https://localhost:8000/exp/studies/j/1647e101-282a-4fde-a32b-4f493d14f57e/8a2b2f04-63eb-485a-8e55-7b9362368f19/",

--- a/packages/lookit-initjspsych/package.json
+++ b/packages/lookit-initjspsych/package.json
@@ -25,11 +25,13 @@
     "dev": "rollup --config rollup.config.dev.mjs --watch",
     "test": "jest --coverage"
   },
+  "dependencies": {
+    "jspsych": "8.0.3"
+  },
   "devDependencies": {
     "@jspsych/config": "^3.0.1"
   },
   "peerDependencies": {
-    "@lookit/data": "^0.2.0",
-    "jspsych": "^8.0.3"
+    "@lookit/data": "^0.2.0"
   }
 }

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -34,3 +34,20 @@ export class UndefinedTypeError extends Error {
     );
   }
 }
+
+/** When a timeline element is incorrectly formatted. */
+export class UndefinedTimelineError extends Error {
+  /**
+   * Inform user that one of the elements on their timeline is formatted
+   * incorrectly.
+   *
+   * @param el - Element in the timeline. Likely a timeline node with an
+   *   incorrect timeline value, or trial object with missing type key/value.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public constructor(el: any) {
+    super(
+      `An element in the timeline is not structured correctly or is missing required information. It may be a timeline node with a timeline array that is the wrong type or missing/undefined, or a trial object with a missing type. Element: ${JSON.stringify(el)}`,
+    );
+  }
+}

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -18,16 +18,19 @@ export class SequenceExpDataError extends Error {
   }
 }
 
-/** When a trial is accidentally undefined. */
+/** When a trial type is accidentally undefined. */
 export class UndefinedTypeError extends Error {
   /**
-   * Inform user that their nth trial is undefined.
+   * Inform user that one of their timeline trial objects is missing the type
+   * parameter.
    *
-   * @param idx - Index of timeline where trial type is undefined
+   * @param object - Timeline object with a type key whose value is
+   *   null/undefined.
    */
-  public constructor(idx: number) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public constructor(object: Record<string, any>) {
     super(
-      `${nth(idx + 1)} trial has an undefined type.  Maybe the type name is misspelled.`,
+      `A trial object in the timeline has an undefined type. Maybe the type name is misspelled, or the plugin you want to use is not supported. Object: ${JSON.stringify(object)}.`,
     );
   }
 }

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -1,14 +1,3 @@
-/**
- * Needed to tell user that their nth trial was undefined.
- * https://stackoverflow.com/a/39466341
- *
- * @param n - Number needing suffix
- * @returns Number with ordinal suffix
- */
-export const nth = (n: number) => {
-  return `${n}${["st", "nd", "rd"][((((n + 90) % 100) - 10) % 10) - 1] || "th"}`;
-};
-
 /** Error when experiment data doesn't contain values on finish. */
 export class SequenceExpDataError extends Error {
   /** Error when experiment data doesn't contain values on finish. */

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -97,30 +97,28 @@ describe("lookit-initjspsych", () => {
   test("Throws UndefinedTimelineError when timeline object is invalid", () => {
     const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
 
-    const t1 = [
-      { timeline: { type: TestPlugin } },
-    ] as unknown as ChsTimelineArray;
+    const t1 = [{ timeline: { type: TestPlugin } }] as ChsTimelineArray;
 
     expect(
-      async () => await jsPsych({}).run(t1 as unknown as ChsTimelineArray),
+      async () => await jsPsych({}).run(t1 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t2 = [{ timeline: true }] as unknown as ChsTimelineArray;
+    const t2 = [{ timeline: true }] as ChsTimelineArray;
 
     expect(
-      async () => await jsPsych({}).run(t2 as unknown as ChsTimelineArray),
+      async () => await jsPsych({}).run(t2 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t3 = [true] as unknown as ChsTimelineArray;
+    const t3 = [true] as ChsTimelineArray;
 
     expect(
-      async () => await jsPsych({}).run(t3 as unknown as ChsTimelineArray),
+      async () => await jsPsych({}).run(t3 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t4 = [42] as unknown as ChsTimelineArray;
+    const t4 = [42] as ChsTimelineArray;
 
     expect(
-      async () => await jsPsych({}).run(t4 as unknown as ChsTimelineArray),
+      async () => await jsPsych({}).run(t4 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
   });
 

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -3,7 +3,6 @@ import TestPlugin from "../fixtures/TestPlugin";
 import lookitInitJsPsych from "./";
 import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
 import type {
-  ChsJsPsych,
   ChsTimelineArray,
   ChsTimelineDescription,
   ChsTrialDescription,
@@ -19,7 +18,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Does lookitInitJsPsych return an instance of jspsych?", () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("uuid-string");
+    const jsPsych = lookitInitJsPsych("uuid-string");
     const opts = {
       on_data_update: jest.fn(),
       on_finish: jest.fn(),
@@ -30,13 +29,13 @@ describe("lookit-initjspsych", () => {
   test("Is jspsych's run called?", async () => {
     const mockRun = jest.fn();
     jest.spyOn(JsPsych.prototype, "run").mockImplementation(mockRun);
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     await jsPsych({}).run([]);
     expect(mockRun).toHaveBeenCalledTimes(1);
   });
 
   test("Is experiment data injected into timeline w/o data?", async () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     const trial: ChsTrialDescription = { type: TestPlugin };
     const t: ChsTimelineArray = [trial];
 
@@ -63,10 +62,20 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Throws UndefinedTypeError when trial description has no type", () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     [
-      [{ type: undefined, data: { other: "data" } } as ChsTrialDescription],
-      [{ type: null, data: { other: "data" } } as ChsTrialDescription],
+      [
+        {
+          type: undefined,
+          data: { other: "data" },
+        } as unknown as ChsTrialDescription,
+      ],
+      [
+        {
+          type: null,
+          data: { other: "data" },
+        } as unknown as ChsTrialDescription,
+      ],
     ].forEach((t) => {
       expect(
         async () => await jsPsych({}).run(t as ChsTimelineArray),
@@ -75,7 +84,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Does the experiment run when the timeline contains a valid timeline node?", async () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     const timeline_node: ChsTimelineDescription = {
       timeline: [
         {
@@ -95,27 +104,29 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Throws UndefinedTimelineError when timeline object is invalid", () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
 
-    const t1 = [{ timeline: { type: TestPlugin } }] as ChsTimelineArray;
+    const t1 = [
+      { timeline: { type: TestPlugin } },
+    ] as unknown as ChsTimelineArray;
 
     expect(
       async () => await jsPsych({}).run(t1 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t2 = [{ timeline: true }] as ChsTimelineArray;
+    const t2 = [{ timeline: true }] as unknown as ChsTimelineArray;
 
     expect(
       async () => await jsPsych({}).run(t2 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t3 = [true] as ChsTimelineArray;
+    const t3 = [true] as unknown as ChsTimelineArray;
 
     expect(
       async () => await jsPsych({}).run(t3 as ChsTimelineArray),
     ).rejects.toThrow(UndefinedTimelineError);
 
-    const t4 = [42] as ChsTimelineArray;
+    const t4 = [42] as unknown as ChsTimelineArray;
 
     expect(
       async () => await jsPsych({}).run(t4 as ChsTimelineArray),
@@ -123,7 +134,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When the timeline array element is an array, handleTrialTypes is called on that array", async () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     const timeline_node_nested_array: ChsTimelineDescription = {
       timeline: [[{ type: TestPlugin, data: { other: "data" } }]],
     };
@@ -141,7 +152,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When a trial description contains a type and nested timeline, handleTrialTypes treats it as a trial instead of timeline node", async () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
+    const jsPsych = lookitInitJsPsych("some id");
     const nested_timeline: ChsTrialDescription = {
       type: TestPlugin,
       timeline: [{ data: { trialnumber: 1 } }, { data: { trialnumber: 2 } }],
@@ -156,11 +167,11 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When a trial description contains a nested timeline with no type, handleTrialTypes handles it as a timeline node", async () => {
-    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
-    const nested_timeline: ChsTrialDescription = {
+    const jsPsych = lookitInitJsPsych("some id");
+    const nested_timeline = {
       data: { somekey: "somevalue" },
       timeline: [{ type: TestPlugin }, { type: TestPlugin }],
-    };
+    } as unknown as ChsTrialDescription;
     const t: ChsTimelineArray = [nested_timeline];
 
     await jsPsych({}).run(t);

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -2,7 +2,7 @@ import { JsPsych } from "jspsych";
 import TestPlugin from "../fixtures/TestPlugin";
 import lookitInitJsPsych from "./";
 import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
-import {
+import type {
   ChsJsPsych,
   ChsTimelineArray,
   ChsTimelineDescription,

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -1,61 +1,180 @@
 import { JsPsych } from "jspsych";
+import TestPlugin from "../fixtures/TestPlugin";
 import lookitInitJsPsych from "./";
-import { UndefinedTypeError } from "./errors";
-import { Timeline } from "./types";
+import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
+import {
+  ChsTimelineArray,
+  ChsTimelineDescription,
+  ChsTrialDescription,
+} from "./types";
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
+describe("lookit-initjspsych", () => {
+  beforeEach(() => {
+    TestPlugin.reset();
+  });
 
-/**
- * Mocked chs data function used in testing below.
- *
- * @returns CHS experiment data.
- */
-const chsData = () => ({ key: "value" });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-test("Does lookitInitJsPsych return an instance of jspsych?", () => {
-  const jsPsych = lookitInitJsPsych("uuid-string");
-  const opts = {
-    on_data_update: jest.fn(),
-    on_finish: jest.fn(),
-  };
-  expect(jsPsych(opts)).toBeInstanceOf(JsPsych);
-});
+  test("Does lookitInitJsPsych return an instance of jspsych?", () => {
+    const jsPsych = lookitInitJsPsych("uuid-string");
+    const opts = {
+      on_data_update: jest.fn(),
+      on_finish: jest.fn(),
+    };
+    expect(jsPsych(opts)).toBeInstanceOf(JsPsych);
+  });
 
-test("Is jspsych's run called?", async () => {
-  const mockRun = jest.fn();
-  jest.spyOn(JsPsych.prototype, "run").mockImplementation(mockRun);
-  const jsPsych = lookitInitJsPsych("some id");
-  await jsPsych({}).run([]);
-  expect(mockRun).toHaveBeenCalledTimes(1);
-});
+  test("Is jspsych's run called?", async () => {
+    const mockRun = jest.fn();
+    jest.spyOn(JsPsych.prototype, "run").mockImplementation(mockRun);
+    const jsPsych = lookitInitJsPsych("some id");
+    await jsPsych({}).run([]);
+    expect(mockRun).toHaveBeenCalledTimes(1);
+  });
 
-test("Is experiment data injected into timeline w/o data?", async () => {
-  const jsPsych = lookitInitJsPsych("some id");
-  const t: Timeline[] = [{ type: { chsData } }];
+  test("Is experiment data injected into timeline w/o data?", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const trial: ChsTrialDescription = { type: TestPlugin };
+    const t: ChsTimelineArray = [trial];
 
-  await jsPsych({}).run(t);
-  expect(t[0].data).toMatchObject({ key: "value" });
-});
+    await jsPsych({}).run(t);
+    // TestPlugin has a chsData() method that returns { chs_type: "test" }
+    expect((t[0] as ChsTrialDescription).data).toMatchObject({
+      chs_type: "test",
+    });
+  });
 
-test("Is experiment data injected into timeline w/ data?", async () => {
-  const jsPsych = lookitInitJsPsych("some id");
-  const t: Timeline[] = [{ type: { chsData }, data: { other: "data" } }];
+  test("Is experiment data injected into timeline w/ data?", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const trial: ChsTrialDescription = {
+      type: TestPlugin,
+      data: { other: "data" },
+    };
+    const t: ChsTimelineArray = [trial];
 
-  await jsPsych({}).run(t);
-  expect(t[0].data).toMatchObject({ key: "value", other: "data" });
-});
+    await jsPsych({}).run(t);
+    expect((t[0] as ChsTrialDescription).data).toMatchObject({
+      chs_type: "test",
+      other: "data",
+    });
+  });
 
-test("Is there an error when experiment type is empty?", () => {
-  const jsPsych = lookitInitJsPsych("some id");
-  [
-    [{ data: { other: "data" } }],
-    [{ type: undefined, data: { other: "data" } }],
-    [{ type: null, data: { other: "data" } }],
-  ].forEach((t) => {
-    expect(async () => await jsPsych({}).run(t)).rejects.toThrow(
-      UndefinedTypeError,
-    );
+  test("Throws UndefinedTypeError when trial description has no type", () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    [
+      [{ type: undefined, data: { other: "data" } } as ChsTrialDescription],
+      [{ type: null, data: { other: "data" } } as ChsTrialDescription],
+    ].forEach((t) => {
+      expect(
+        async () => await jsPsych({}).run(t as TrialDescription[]),
+      ).rejects.toThrow(UndefinedTypeError);
+    });
+  });
+
+  test("Does the experiment run when the timeline contains a valid timeline node?", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const timeline_node: ChsTimelineDescription = {
+      timeline: [
+        {
+          timeline: [{ type: TestPlugin, data: { other: "data" } }],
+        },
+      ],
+    };
+    const t: ChsTimelineArray = [timeline_node];
+
+    await jsPsych({}).run(t);
+
+    const trial_data = (
+      ((t[0] as ChsTimelineDescription).timeline[0] as ChsTimelineDescription)
+        .timeline[0] as ChsTrialDescription
+    ).data;
+    expect(trial_data).toMatchObject({ chs_type: "test", other: "data" });
+  });
+
+  test("Throws UndefinedTimelineError when timeline object is invalid", () => {
+    const jsPsych = lookitInitJsPsych("some id");
+
+    const t1 = [
+      { timeline: { type: TestPlugin } },
+    ] as unknown as ChsTimelineArray;
+
+    expect(
+      async () => await jsPsych({}).run(t1 as unknown as ChsTimelineArray),
+    ).rejects.toThrow(UndefinedTimelineError);
+
+    const t2 = [{ timeline: true }] as unknown as ChsTimelineArray;
+
+    expect(
+      async () => await jsPsych({}).run(t2 as unknown as ChsTimelineArray),
+    ).rejects.toThrow(UndefinedTimelineError);
+
+    const t3 = [true] as unknown as ChsTimelineArray;
+
+    expect(
+      async () => await jsPsych({}).run(t3 as unknown as ChsTimelineArray),
+    ).rejects.toThrow(UndefinedTimelineError);
+
+    const t4 = [42] as unknown as ChsTimelineArray;
+
+    expect(
+      async () => await jsPsych({}).run(t4 as unknown as ChsTimelineArray),
+    ).rejects.toThrow(UndefinedTimelineError);
+  });
+
+  test("When the timeline array element is an array, handleTrialTypes is called on that array", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const timeline_node_nested_array: ChsTimelineDescription = {
+      timeline: [[{ type: TestPlugin, data: { other: "data" } }]],
+    };
+    const t: ChsTimelineArray = [timeline_node_nested_array];
+
+    await jsPsych({}).run(t);
+
+    const outerTimelineNode = t[0] as ChsTimelineDescription;
+    const trial_data = (
+      (
+        outerTimelineNode.timeline[0] as ChsTimelineArray
+      )[0] as ChsTrialDescription
+    ).data;
+    expect(trial_data).toMatchObject({ chs_type: "test", other: "data" });
+  });
+
+  test("When a trial description contains a type and nested timeline, handleTrialTypes treats it as a trial instead of timeline node", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const nested_timeline: ChsTrialDescription = {
+      type: TestPlugin,
+      timeline: [{ data: { trialnumber: 1 } }, { data: { trialnumber: 2 } }],
+    };
+    const t: ChsTimelineArray = [nested_timeline];
+
+    await jsPsych({}).run(t);
+
+    expect((t[0] as ChsTrialDescription).data).toMatchObject({
+      chs_type: "test",
+    });
+  });
+
+  test("When a trial description contains a nested timeline with no type, handleTrialTypes handles it as a timeline node", async () => {
+    const jsPsych = lookitInitJsPsych("some id");
+    const nested_timeline: ChsTrialDescription = {
+      data: { somekey: "somevalue" },
+      timeline: [{ type: TestPlugin }, { type: TestPlugin }],
+    };
+    const t: ChsTimelineArray = [nested_timeline];
+
+    await jsPsych({}).run(t);
+
+    // lookit-initjspsych should get the CHS data from TestPlugin and add it as data in the nested timeline.
+    expect((t[0] as ChsTrialDescription).data).toMatchObject({
+      somekey: "somevalue",
+    });
+    expect((t[0] as ChsTrialDescription).timeline[0].data).toMatchObject({
+      chs_type: "test",
+    });
+    expect((t[0] as ChsTrialDescription).timeline[1].data).toMatchObject({
+      chs_type: "test",
+    });
   });
 });

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -3,6 +3,7 @@ import TestPlugin from "../fixtures/TestPlugin";
 import lookitInitJsPsych from "./";
 import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
 import {
+  ChsJsPsych,
   ChsTimelineArray,
   ChsTimelineDescription,
   ChsTrialDescription,
@@ -18,7 +19,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Does lookitInitJsPsych return an instance of jspsych?", () => {
-    const jsPsych = lookitInitJsPsych("uuid-string");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("uuid-string");
     const opts = {
       on_data_update: jest.fn(),
       on_finish: jest.fn(),
@@ -29,13 +30,13 @@ describe("lookit-initjspsych", () => {
   test("Is jspsych's run called?", async () => {
     const mockRun = jest.fn();
     jest.spyOn(JsPsych.prototype, "run").mockImplementation(mockRun);
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     await jsPsych({}).run([]);
     expect(mockRun).toHaveBeenCalledTimes(1);
   });
 
   test("Is experiment data injected into timeline w/o data?", async () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     const trial: ChsTrialDescription = { type: TestPlugin };
     const t: ChsTimelineArray = [trial];
 
@@ -62,19 +63,19 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Throws UndefinedTypeError when trial description has no type", () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     [
       [{ type: undefined, data: { other: "data" } } as ChsTrialDescription],
       [{ type: null, data: { other: "data" } } as ChsTrialDescription],
     ].forEach((t) => {
       expect(
-        async () => await jsPsych({}).run(t as TrialDescription[]),
+        async () => await jsPsych({}).run(t as ChsTimelineArray),
       ).rejects.toThrow(UndefinedTypeError);
     });
   });
 
   test("Does the experiment run when the timeline contains a valid timeline node?", async () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     const timeline_node: ChsTimelineDescription = {
       timeline: [
         {
@@ -94,7 +95,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("Throws UndefinedTimelineError when timeline object is invalid", () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
 
     const t1 = [
       { timeline: { type: TestPlugin } },
@@ -124,7 +125,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When the timeline array element is an array, handleTrialTypes is called on that array", async () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     const timeline_node_nested_array: ChsTimelineDescription = {
       timeline: [[{ type: TestPlugin, data: { other: "data" } }]],
     };
@@ -142,7 +143,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When a trial description contains a type and nested timeline, handleTrialTypes treats it as a trial instead of timeline node", async () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     const nested_timeline: ChsTrialDescription = {
       type: TestPlugin,
       timeline: [{ data: { trialnumber: 1 } }, { data: { trialnumber: 2 } }],
@@ -157,7 +158,7 @@ describe("lookit-initjspsych", () => {
   });
 
   test("When a trial description contains a nested timeline with no type, handleTrialTypes handles it as a timeline node", async () => {
-    const jsPsych = lookitInitJsPsych("some id");
+    const jsPsych: ChsJsPsych = lookitInitJsPsych("some id");
     const nested_timeline: ChsTrialDescription = {
       data: { somekey: "somevalue" },
       timeline: [{ type: TestPlugin }, { type: TestPlugin }],

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -1,6 +1,6 @@
 import { initJsPsych as origInitJsPsych } from "jspsych";
 import { UndefinedTypeError } from "./errors";
-import { JsPsychOptions, Timeline } from "./types";
+import { ChsTrialDescription, JsPsychOptions } from "./types";
 import { on_data_update, on_finish } from "./utils";
 
 /**
@@ -10,7 +10,7 @@ import { on_data_update, on_finish } from "./utils";
  *
  * @param t - Timeline object.
  */
-const addChsData = (t: Timeline) => {
+const addChsData = (t: ChsTrialDescription) => {
   if (t.type.chsData) {
     t.data = { ...t.data, ...t.type.chsData() };
   }
@@ -40,7 +40,7 @@ const lookitInitJsPsych = (responseUuid: string) => {
      */
     jsPsych.run = function (timeline) {
       // check timeline here...
-      timeline.map((t: Timeline, idx: number) => {
+      timeline.map((t: ChsTrialDescription, idx: number) => {
         if (!t.type) {
           throw new UndefinedTypeError(idx);
         }

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -1,19 +1,50 @@
 import { initJsPsych as origInitJsPsych } from "jspsych";
-import { UndefinedTypeError } from "./errors";
-import { ChsTrialDescription, JsPsychOptions } from "./types";
+import { TimelineArray } from "jspsych/src/timeline";
+import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
+import {
+  ChsTimelineArray,
+  ChsTimelineDescription,
+  ChsTrialDescription,
+  JsPsychOptions,
+} from "./types";
 import { on_data_update, on_finish } from "./utils";
 
 /**
- * Search timeline object for the method "chsData". When found, add to timeline
- * data parameter. This will inject values into the experiment to be parsed chs
- * after experiment has completed.
+ * Checks if the given description is a timeline array or description (node),
+ * both of which might contain trial descriptions. Modified from
+ * isTimelineDescription in jspsych/src/timeline to exclude trial descriptions
+ * with nested timelines (jsPsych returns true for trial description objects
+ * that have a "type" property and a nested timelines, but we need to return
+ * false.)
  *
- * @param t - Timeline object.
+ * @param description - The description array or object to check.
+ * @returns True if the description is a timeline array or timeline description
+ *   (object with "timeline" key but no "type" key), otherwise false.
  */
-const addChsData = (t: ChsTrialDescription) => {
-  if (t.type.chsData) {
-    t.data = { ...t.data, ...t.type.chsData() };
-  }
+const isTimelineNodeArray = (
+  description: ChsTrialDescription | ChsTimelineDescription | ChsTimelineArray,
+) => {
+  return (
+    (Boolean((description as ChsTimelineDescription).timeline) ||
+      Array.isArray(description)) &&
+    !(description as ChsTimelineDescription).type
+  );
+};
+
+/**
+ * Checks if the description is an object that contains a "type" key, whose
+ * value is a plugin class. Returns true even when the trial object contains a
+ * nested timeline. Modified from isTrialDescription in jspsych/src/timeline to
+ * return true for trial descriptions with nested timelines.
+ *
+ * @param description - The description object to check.
+ * @returns True if the description is an object with a "type" property,
+ *   otherwise false.
+ */
+const isTrialWithType = (
+  description: ChsTrialDescription | ChsTimelineDescription,
+) => {
+  return typeof description === "object" && !isTimelineNodeArray(description);
 };
 
 /**
@@ -35,19 +66,81 @@ const lookitInitJsPsych = (responseUuid: string) => {
      * Overriding default jsPsych run function. This will allow us to
      * check/alter the timeline before running an experiment.
      *
-     * @param timeline - List of jsPsych trials.
+     * @param timeline - Array of jsPsych trials (descriptions) and/or timeline
+     *   nodes (descriptions).
      * @returns Original jsPsych run function.
      */
-    jsPsych.run = function (timeline) {
-      // check timeline here...
-      timeline.map((t: ChsTrialDescription, idx: number) => {
-        if (!t.type) {
-          throw new UndefinedTypeError(idx);
-        }
-        addChsData(t);
-      });
+    jsPsych.run = function (timeline: TimelineArray) {
+      /**
+       * Iterate over a timeline and recursively locate any trial descriptions
+       * (objects with a "type" key, whose value is a plugin class). For each
+       * trial description, call the callback function that receives the trial
+       * description as an argument.
+       *
+       * @param timeline - CHS versions of the jsPsych timeline array or
+       *   timeline description
+       * @param callback - Callback function that handles each plugin class,
+       *   which receives as an argument the plugin class from the trial
+       *   description "type".
+       * @returns Timeline array
+       */
+      const handleTrialTypes = (
+        timeline: ChsTimelineArray | ChsTimelineDescription,
+        callback: (trial: ChsTrialDescription) => void,
+      ): ChsTimelineArray => {
+        return timeline.map(
+          (
+            el: ChsTimelineDescription | ChsTrialDescription | ChsTimelineArray,
+          ) => {
+            // First check for timeline descriptions: arrays or objects with 'timeline' key that do not also have a 'type' key.
+            if (isTimelineNodeArray(el)) {
+              if (Array.isArray(el)) {
+                return handleTrialTypes(el, callback);
+              } else if ("timeline" in el && Array.isArray(el.timeline)) {
+                el.timeline = handleTrialTypes(el.timeline, callback);
+                return el;
+              } else {
+                throw new UndefinedTimelineError(el);
+              }
+            } else if (
+              isTrialWithType(
+                el as ChsTimelineDescription | ChsTrialDescription,
+              )
+            ) {
+              // Now handle objects with a 'type' key. This includes trial descriptions with nested timelines, as long as they include a plugin type.
+              if (
+                el !== null &&
+                "type" in el &&
+                el.type !== null &&
+                el.type !== undefined
+              ) {
+                callback(el as ChsTrialDescription);
+                return el;
+              } else {
+                throw new UndefinedTypeError(el);
+              }
+            } else {
+              throw new UndefinedTimelineError(el);
+            }
+          },
+        );
+      };
 
-      return origJsPsychRun(timeline);
+      // Note about type conversion here: This function takes the timeline passed to jsPsych.run, so it must be typed as a jsPsych timeline array for compatibility with that original function, but in fact it is the CHS version of the timeline array.
+      const modifiedTimeline = handleTrialTypes(
+        timeline as ChsTimelineArray | ChsTimelineDescription,
+        (trial) => {
+          // Search timeline object for the method "chsData". When found, add to timeline data parameter. This will inject values into the experiment to be parsed chs after experiment has completed.
+          if ("type" in trial) {
+            if (trial.type?.chsData) {
+              trial.data = { ...trial.data, ...trial.type.chsData() };
+            }
+          }
+        },
+      );
+
+      // Note about type conversion here: We need to convert the CHS-typed (extended) timeline array back to the jsPsych-typed version for compatibility with the original jsPsych.run function.
+      return origJsPsychRun(modifiedTimeline as TimelineArray);
     };
 
     return jsPsych;

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -1,7 +1,7 @@
 import { initJsPsych as origInitJsPsych } from "jspsych";
-import { TimelineArray } from "jspsych/src/timeline";
+import type { TimelineArray } from "jspsych/src/timeline";
 import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
-import {
+import type {
   ChsJsPsych,
   ChsTimelineArray,
   ChsTimelineDescription,

--- a/packages/lookit-initjspsych/src/types.ts
+++ b/packages/lookit-initjspsych/src/types.ts
@@ -1,5 +1,6 @@
 import { JsPsychExpData } from "@lookit/data/dist/types";
 import { DataCollection } from "jspsych";
+import { TrialDescription } from "jspsych/src/timeline";
 
 export type UserFuncOnDataUpdate = (data: JsPsychExpData) => void;
 export type UserFuncOnFinish = (data: DataCollection) => void;
@@ -9,7 +10,7 @@ export type JsPsychOptions = {
   on_finish?: UserFuncOnFinish;
 };
 
-export type Timeline = {
+export type ChsTrialDescription = TrialDescription & {
   type: {
     chsData?: () => object;
   };

--- a/packages/lookit-initjspsych/src/types.ts
+++ b/packages/lookit-initjspsych/src/types.ts
@@ -1,6 +1,10 @@
 import { JsPsychExpData } from "@lookit/data/dist/types";
-import { DataCollection } from "jspsych";
-import { TrialDescription } from "jspsych/src/timeline";
+import { DataCollection, JsPsychPlugin } from "jspsych";
+import {
+  PluginInfo,
+  UniversalPluginParameters,
+} from "jspsych/src/modules/plugins";
+import { TimelineDescription, TrialDescription } from "jspsych/src/timeline";
 
 export type UserFuncOnDataUpdate = (data: JsPsychExpData) => void;
 export type UserFuncOnFinish = (data: DataCollection) => void;
@@ -10,9 +14,24 @@ export type JsPsychOptions = {
   on_finish?: UserFuncOnFinish;
 };
 
-export type ChsTrialDescription = TrialDescription & {
-  type: {
+// Add chsData to JsPsychPlugin type
+export type ChsJsPsychPlugin = JsPsychPlugin<PluginInfo> &
+  UniversalPluginParameters & {
     chsData?: () => object;
   };
-  data?: object;
-};
+
+// Modify trial description to allow for plugin classes with chsData
+export interface ChsTrialDescription extends Omit<TrialDescription, "type"> {
+  type: ChsJsPsychPlugin;
+}
+
+// Modify timeline description to allow for plugin classes with chsData
+export interface ChsTimelineDescription
+  extends Omit<TimelineDescription, "timeline"> {
+  timeline: ChsTimelineArray;
+}
+
+// Modify timeline array to allow for plugin classes with chsData
+export type ChsTimelineArray = Array<
+  ChsTimelineDescription | ChsTrialDescription | ChsTimelineArray
+>;

--- a/packages/lookit-initjspsych/src/types.ts
+++ b/packages/lookit-initjspsych/src/types.ts
@@ -1,5 +1,9 @@
 import { JsPsychExpData } from "@lookit/data/dist/types";
-import { DataCollection, JsPsychPlugin } from "jspsych";
+import {
+  DataCollection,
+  JsPsych as OriginalJsPsych,
+  JsPsychPlugin,
+} from "jspsych";
 import {
   PluginInfo,
   UniversalPluginParameters,
@@ -35,3 +39,7 @@ export interface ChsTimelineDescription
 export type ChsTimelineArray = Array<
   ChsTimelineDescription | ChsTrialDescription | ChsTimelineArray
 >;
+
+export interface ChsJsPsych extends Omit<OriginalJsPsych, "run"> {
+  run(timeline: ChsTimelineDescription | ChsTimelineArray): Promise<void>;
+}

--- a/packages/lookit-initjspsych/src/types.ts
+++ b/packages/lookit-initjspsych/src/types.ts
@@ -1,14 +1,17 @@
-import { JsPsychExpData } from "@lookit/data/dist/types";
-import {
+import type { JsPsychExpData } from "@lookit/data/dist/types";
+import type {
   DataCollection,
   JsPsych as OriginalJsPsych,
   JsPsychPlugin,
 } from "jspsych";
-import {
+import type {
   PluginInfo,
   UniversalPluginParameters,
 } from "jspsych/src/modules/plugins";
-import { TimelineDescription, TrialDescription } from "jspsych/src/timeline";
+import type {
+  TimelineDescription,
+  TrialDescription,
+} from "jspsych/src/timeline";
 
 export type UserFuncOnDataUpdate = (data: JsPsychExpData) => void;
 export type UserFuncOnFinish = (data: DataCollection) => void;

--- a/packages/lookit-initjspsych/src/utils.spec.ts
+++ b/packages/lookit-initjspsych/src/utils.spec.ts
@@ -1,7 +1,7 @@
 import { DataCollection } from "jspsych";
 
 import { Child, JsPsychExpData, Study } from "@lookit/data/dist/types";
-import { nth, SequenceExpDataError } from "./errors";
+import { SequenceExpDataError } from "./errors";
 import { on_data_update, on_finish } from "./utils";
 
 delete global.window.location;
@@ -143,15 +143,4 @@ test("Is an error thrown when experiment sequence is undefined?", () => {
   expect(async () => {
     await on_finish("some id", userFn)(data);
   }).rejects.toThrow(SequenceExpDataError);
-});
-
-test("Ordinal format of numbers", () => {
-  [
-    { a: 1, b: "1st" },
-    { a: 2, b: "2nd" },
-    { a: 3, b: "3rd" },
-    { a: 146, b: "146th" },
-  ].forEach(({ a, b }) => {
-    expect(nth(a)).toStrictEqual(b);
-  });
 });

--- a/rollup.mjs
+++ b/rollup.mjs
@@ -33,13 +33,14 @@ export function makeRollupConfig(iifeName) {
    * @param log - Log object containing location, frame, and message.
    * @param handler - Function called to record log.
    */
-  const onLog = (level, log) => {
+  const onLog = (level, log, handler) => {
     // Don't log known circular dependencies with the data package.
     if (log.code === "CIRCULAR_DEPENDENCY" && iifeName === packages.data.iife) {
       if (knownCircularDeps.some((value) => log.message.includes(value))) {
         return;
       }
     }
+    handler(level, log);
   };
 
   return jsPsychMakeRollupConfig(iifeName).map((config) => {


### PR DESCRIPTION
Fixes #130 

This PR fixes the problem with CHS jsPsych studies throwing an error when the experiment contains a timeline node (object with a "timeline" property). The error occurs because are iterating through the experiment timeline to find all of the trial types (to call their chsData methods, and probably for other reasons in the future), and we are throwing errors when the "type" key is missing or null/undefined. 

This PR fixes the problem by implementing a recursive search of timeline arrays to check for any plugin types in trial objects. Errors are still thrown if the "type" property exists but its value is null/undefined. But now, instead of throwing an error when the "type" property is missing, it also checks to see if the element is an array or timeline node (i.e. has a "timeline" property).

To summarize, errors are thrown if any element on the timeline:

- is an object with a "type" property, but the type value is null, undefined, or not a plugin class
- is not an object or array
- is missing both a "type" and "timeline" property
- has a "timeline" property, but its value is null, undefined, or not an array

Other changes:

- Import types from jsPsych and extend them to account for custom CHS plugins
- Fixed and add tests

A few remaining issues:

- I copied in the `TestPlugin` from jsPsych for use in our tests, and modified it to make it a CHS-jsPsych plugin type. Ideally this would be imported and then extended, but it's not exposed by jsPsych. I can put in a jsPsych PR if we want to keep this class. Or I can simplify our version so that it just has what we need for our current tests.
- I'm getting TypeScript errors in `index.spec.ts` that I can't figure out how to fix. The tests still pass but I would like to get rid of the errors if possible. I _think_ it's because of an argument type mismatch in `jsPsych.run` but my attempts to fix it with various type assertions have not worked :confused:.

Notes:

A more recent version of jsPsych allows users to dynamically modify the experiment timeline at runtime: https://www.jspsych.org/latest/overview/timeline/#modifying-timelines-at-runtime This could potentially cause us to miss any checks that we do on the timeline when `jsPsych.run` is first called.