### PR TITLE
Wait to enable playback button until after recording URL is created

### DIFF
--- a/.changeset/blue-seals-warn.md
+++ b/.changeset/blue-seals-warn.md
@@ -1,0 +1,6 @@
+---
+"@lookit/record": patch
+---
+
+Fixes a problem with the consent video plugin in which the user can try to
+replay a video recording before the it has fully stopped.

--- a/.changeset/calm-tomatoes-warn.md
+++ b/.changeset/calm-tomatoes-warn.md
@@ -1,6 +1,0 @@
----
-"@lookit/record": patch
----
-
-Fix recording playback issues, which were caused by not specifying codecs in the
-recorder mime type.

--- a/.changeset/khaki-flowers-prove.md
+++ b/.changeset/khaki-flowers-prove.md
@@ -1,6 +1,0 @@
----
-"@lookit/lookit-initjspsych": patch
----
-
-Fixed bug that was causing errors when running a jsPsych study that contained a
-timeline node.

--- a/.changeset/tricky-islands-visit.md
+++ b/.changeset/tricky-islands-visit.md
@@ -1,5 +1,0 @@
----
-"@lookit/record": patch
----
-
-Update the documentation.

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -246,8 +246,8 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
     stop.addEventListener("click", async () => {
       stop.disabled = true;
       record.disabled = false;
-      play.disabled = false;
       await this.recorder.stop();
+      play.disabled = false;
       this.recorder.reset();
       this.recordFeed(display);
     });


### PR DESCRIPTION
This addresses part of #133 but probably doesn't fully solve the problem.

After a consent video recording starts and then the recording is stopped, the playback button was enabled before the recorder's stop event handler was triggered. It might've been possible for a user to try to playback a video whose source URL had not been created yet. (Simulating this sequence event with a `setTimeout` around the `URL.createObjectURL` line reproduces the plugin's stuck state, and this PR fixes that problem).  

This PR changes the recording stop event handler so that the playback button is only enabled after the recorder is fully stopped. This helps prevent a race condition between creating the recording URL and trying to replay it. However, if something goes wrong with the recording URL creation (e.g. blob is empty), then the user will still be left in a "stuck" state. So there are a few other things we should do to address this problem, which I put on [this comment](https://github.com/lookit/lookit-jspsych/issues/133#issuecomment-2773914384) in the issue thread.

Note: I branched this off of `develop` and noticed that the old changeset files are still there... Those changes have already been released, and the changeset files have been removed on `main` (they're removed automatically when we do the release on that branch). I'm not sure what I need to do to prevent/fix this when we do future releases?