### PR TITLE
Video consent: improve formatting, add translated messages

### DIFF
--- a/.changeset/tough-planes-shout.md
+++ b/.changeset/tough-planes-shout.md
@@ -1,0 +1,14 @@
+---
+"@lookit/templates": minor
+"@lookit/record": minor
+"@lookit/style": minor
+---
+
+- Templates:
+  - add message container to video consent template
+  - add public `translateString` method for translating string directly
+- Record:
+  - add translated status messages to the video consent plugin: not recording,
+    starting, recording, stopping/uploading
+  - wait to enable/diable certain buttons until recorder has fully
+    started/stopped

--- a/packages/record/scss/consent-video-plugin.scss
+++ b/packages/record/scss/consent-video-plugin.scss
@@ -61,6 +61,13 @@ div#consent-video-trial {
     text-align: justify;
   }
 
+  #lookit-jspsych-video-msg-container {
+    min-height: 1lh;
+    text-align: center;
+    font-weight: bold;
+    color: red;
+  }
+
   #lookit-jspsych-video-container {
     position: relative;
     margin: auto;

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -262,12 +262,12 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
     record.addEventListener("click", async () => {
       this.addMessage(display, this.startingMsg!);
       record.disabled = true;
-      stop.disabled = false;
       play.disabled = true;
       next.disabled = true;
-      this.getImg(display, "record-icon").style.visibility = "visible";
       await this.recorder.start(true, VideoConsentPlugin.info.name);
+      this.getImg(display, "record-icon").style.visibility = "visible";
       this.addMessage(display, this.recordingMsg!);
+      stop.disabled = false;
     });
   }
 

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -299,14 +299,14 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
 
     stop.addEventListener("click", async () => {
       stop.disabled = true;
-      record.disabled = false;
       this.addMessage(display, this.uploadingMsg!);
       await this.recorder.stop();
-      play.disabled = false;
       this.recorder.reset();
       this.recordFeed(display);
       this.getImg(display, "record-icon").style.visibility = "hidden";
       this.addMessage(display, this.notRecordingMsg!);
+      play.disabled = false;
+      record.disabled = false;
     });
   }
   /**

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -154,7 +154,10 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
    */
   private playbackFeed(display: HTMLElement) {
     const videoContainer = this.getVideoContainer(display);
-    this.recorder.insertPlaybackFeed(videoContainer, this.onEnded(display));
+    this.recorder.insertPlaybackFeed(
+      videoContainer,
+      this.onPlaybackEnded(display),
+    );
   }
 
   /**
@@ -190,13 +193,13 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
   }
 
   /**
-   * Put back the webcam feed once the video recording has ended. This is used
-   * with the "ended" Event.
+   * Put back the webcam feed once the video recording playback has ended. This
+   * is used with the "ended" Event.
    *
    * @param display - JsPsych display HTML element.
    * @returns Event function
    */
-  private onEnded(display: HTMLElement) {
+  private onPlaybackEnded(display: HTMLElement) {
     return () => {
       const next = this.getButton(display, "next");
       const play = this.getButton(display, "play");

--- a/packages/record/src/errors.ts
+++ b/packages/record/src/errors.ts
@@ -196,25 +196,16 @@ export class CreateURLError extends Error {
   }
 }
 
-/** Error thrown when video container couldn't be found. */
-export class VideoContainerNotFoundError extends Error {
-  /** No video container found. */
-  public constructor() {
-    super("Video Container could not be found.");
-    this.name = "VideoContainerError";
-  }
-}
-
-/** Error thrown when button not found. */
-export class ButtonNotFoundError extends Error {
+/** Error thrown when an HTML element is not found. */
+export class ElementNotFoundError extends Error {
   /**
-   * Button couldn't be found by ID field.
+   * Element couldn't be found by ID field.
    *
    * @param id - HTML ID parameter.
    */
   public constructor(id: string) {
-    super(`"${id}" button not found.`);
-    this.name = "ButtonNotFoundError";
+    super(`"${id}" not found.`);
+    this.name = "ElementNotFoundError";
   }
 }
 

--- a/packages/style/src/index.css
+++ b/packages/style/src/index.css
@@ -9083,6 +9083,12 @@ div#consent-video-trial .consent-statement {
   border-radius: 4px;
   text-align: justify;
 }
+div#consent-video-trial #lookit-jspsych-video-msg-container {
+  min-height: 1lh;
+  text-align: center;
+  font-weight: bold;
+  color: red;
+}
 div#consent-video-trial #lookit-jspsych-video-container {
   position: relative;
   margin: auto;

--- a/packages/templates/hbs/consent-video-trial.hbs
+++ b/packages/templates/hbs/consent-video-trial.hbs
@@ -1,6 +1,9 @@
 <div id="consent-video-trial">
   <div class="left-column">{{{consent}}}</div>
   <div class="right-column">
+    <div id="{{msg_container_id}}">{{t
+        "exp-lookit-video-consent.Not-recording"
+      }}</div>
     <div id="{{video_container_id}}" class="jspsych-content"></div>
 
     <ol>

--- a/packages/templates/src/consentVideoTemplate.ts
+++ b/packages/templates/src/consentVideoTemplate.ts
@@ -10,6 +10,7 @@ import { setLocale } from "./utils";
 declare const window: LookitWindow;
 
 const video_container_id = "lookit-jspsych-video-container";
+const msg_container_id = "lookit-jspsych-video-msg-container";
 
 /**
  * Translate, render, and get consent document HTML.
@@ -36,6 +37,7 @@ export const consentVideo = (trial: TrialType<PluginInfo>) => {
     ...trial,
     consent,
     video_container_id,
+    msg_container_id,
   });
 };
 

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,6 +1,13 @@
 import { consentVideo } from "./consentVideoTemplate";
 import { exitSurvey } from "./exitSurveyTemplate";
 import { uploadingVideo } from "./uploadingVideoTemplate";
+import { translateString } from "./utils";
 import { videoConfig } from "./videoConfigTemplate";
 
-export default { consentVideo, videoConfig, uploadingVideo, exitSurvey };
+export default {
+  consentVideo,
+  videoConfig,
+  uploadingVideo,
+  exitSurvey,
+  translateString,
+};

--- a/packages/templates/src/utils.ts
+++ b/packages/templates/src/utils.ts
@@ -92,3 +92,15 @@ Handlebars.registerHelper("t", (context, { hash }) => {
   const txt = String(i18next.t(context, hash));
   return hash.htmlSafe ? new Handlebars.SafeString(txt) : txt;
 });
+
+/**
+ * Public method for directly translating a string, without a corresponding
+ * template.
+ *
+ * @param messageIdStr - Message ID string to be looked up in the translation
+ *   files.
+ * @returns Translated string
+ */
+export const translateString = (messageIdStr: string) => {
+  return i18next.t(messageIdStr);
+};


### PR DESCRIPTION
This PR makes the following changes:
- Templates package:
  - new public `translateString` method for translating a string directly (without a template)
  - add message container to the video-consent plugin template
 - Record package:
   - add translated messages above the webcam feed to reflect the recorder state: not recording, starting, recording, uploading/stopping
   - wait until recorder has fully started before enabling the stop button and showing the record icon
   - wait until recorder has fully stopped before hiding the record icon and enabling the play/record buttons
 - Style package: add CSS for the video-consent plugin's message container