### PR TITLE
Recorder webcam feed formatting: fix layout jump

### DIFF
--- a/packages/record/scss/index.scss
+++ b/packages/record/scss/index.scss
@@ -3,4 +3,5 @@
 
 video.webcam-feed {
   transform: rotateY(180deg);
+  display: block;
 }

--- a/packages/record/src/consentVideo.ts
+++ b/packages/record/src/consentVideo.ts
@@ -246,7 +246,7 @@ export class VideoConsentPlugin implements JsPsychPlugin<Info> {
     stop.addEventListener("click", async () => {
       stop.disabled = true;
       record.disabled = false;
-      await this.recorder.stop();
+      await this.recorder.stop(true);
       play.disabled = false;
       this.recorder.reset();
       this.recordFeed(display);

--- a/packages/record/src/recorder.spec.ts
+++ b/packages/record/src/recorder.spec.ts
@@ -123,6 +123,7 @@ test("Recorder no stop promise", () => {
 
   expect(async () => await rec.stop()).rejects.toThrow(NoStopPromiseError);
 });
+
 test("Recorder initialize error", () => {
   const jsPsych = initJsPsych();
   const rec = new Recorder(jsPsych);
@@ -272,6 +273,125 @@ test("Webcam feed is removed when stream access stops", async () => {
 
   // Reset the document body.
   document.body.innerHTML = "";
+});
+
+test("Webcam feed container maintains size with recorder.stop(true)", async () => {
+  // Add webcam container to document body.
+  const webcam_container_id = "webcam-container";
+  document.body.innerHTML = `<div id="${webcam_container_id}"></div>`;
+  const webcam_div = document.getElementById(
+    webcam_container_id,
+  ) as HTMLDivElement;
+
+  const jsPsych = initJsPsych();
+  const rec = new Recorder(jsPsych);
+  const stopPromise = Promise.resolve();
+
+  rec["stopPromise"] = stopPromise;
+  rec.insertWebcamFeed(webcam_div);
+
+  // Mock the return values for the video element's offsetHeight/offsetWidth, which are used to set the container size
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetWidth", "get")
+    .mockImplementation(() => 400);
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetHeight", "get")
+    .mockImplementation(() => 300);
+
+  await rec.stop(true);
+
+  // Container div's dimensions should match the video element dimensions
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .width,
+  ).toBe("400px");
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .height,
+  ).toBe("300px");
+
+  document.body.innerHTML = "";
+  // restore the offsetWidth/offsetHeight getters
+  jest.restoreAllMocks();
+});
+
+test("Webcam feed container size is not maintained with recorder.stop(false)", async () => {
+  // Add webcam container to document body.
+  const webcam_container_id = "webcam-container";
+  document.body.innerHTML = `<div id="${webcam_container_id}"></div>`;
+  const webcam_div = document.getElementById(
+    webcam_container_id,
+  ) as HTMLDivElement;
+
+  const jsPsych = initJsPsych();
+  const rec = new Recorder(jsPsych);
+  const stopPromise = Promise.resolve();
+
+  rec["stopPromise"] = stopPromise;
+  rec.insertWebcamFeed(webcam_div);
+
+  // Mock the return values for the video element offsetHeight/offsetWidth, which are used to set the container size
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetWidth", "get")
+    .mockImplementation(() => 400);
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetHeight", "get")
+    .mockImplementation(() => 300);
+
+  await rec.stop(false);
+
+  // Container div's dimensions should not be set
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .width,
+  ).toBe("");
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .height,
+  ).toBe("");
+
+  document.body.innerHTML = "";
+  // restore the offsetWidth/offsetHeight getters
+  jest.restoreAllMocks();
+});
+
+test("Webcam feed container size is not maintained with recorder.stop()", async () => {
+  // Add webcam container to document body.
+  const webcam_container_id = "webcam-container";
+  document.body.innerHTML = `<div id="${webcam_container_id}"></div>`;
+  const webcam_div = document.getElementById(
+    webcam_container_id,
+  ) as HTMLDivElement;
+
+  const jsPsych = initJsPsych();
+  const rec = new Recorder(jsPsych);
+  const stopPromise = Promise.resolve();
+
+  rec["stopPromise"] = stopPromise;
+  rec.insertWebcamFeed(webcam_div);
+
+  // Mock the return values for the video element offsetHeight/offsetWidth, which are used to set the container size
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetWidth", "get")
+    .mockImplementation(() => 400);
+  jest
+    .spyOn(document.getElementsByTagName("video")[0], "offsetHeight", "get")
+    .mockImplementation(() => 300);
+
+  await rec.stop();
+
+  // Container div's dimensions should not be set
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .width,
+  ).toBe("");
+  expect(
+    (document.getElementById(webcam_container_id) as HTMLDivElement).style
+      .height,
+  ).toBe("");
+
+  document.body.innerHTML = "";
+  jest.restoreAllMocks();
 });
 
 test("Recorder initializeRecorder", () => {

--- a/packages/record/src/recorder.ts
+++ b/packages/record/src/recorder.ts
@@ -276,13 +276,19 @@ export default class Recorder {
    * tracks, clear the webcam feed element (if there is one), and return the
    * stop promise. This should only be called after recording has started.
    *
+   * @param maintain_container_size - Optional boolean indicating whether or not
+   *   to maintain the current size of the webcam feed container when removing
+   *   the video element. Default is false. If true, the container will be
+   *   resized to match the dimensions of the video element before it is
+   *   removed. This is useful for avoiding layout jumps when the webcam
+   *   container will be re-used during the trial.
    * @returns Promise that resolves after the media recorder has stopped and
    *   final 'dataavailable' event has occurred, when the "stop" event-related
    *   callback function is called.
    */
-  public stop() {
+  public stop(maintain_container_size: boolean = false) {
+    this.clearWebcamFeed(maintain_container_size);
     this.stopTracks();
-    this.clearWebcamFeed();
 
     if (!this.stopPromise) {
       throw new NoStopPromiseError();
@@ -353,12 +359,30 @@ export default class Recorder {
     }
   }
 
-  /** Private helper to clear the webcam feed, if there is one. */
-  private clearWebcamFeed() {
+  /**
+   * Private helper to clear the webcam feed, if there is one. If remove is
+   * false, the video element source attribute is cleared and the parent div
+   * will be set to the same dimensions. This is useful for avoiding layout
+   * jumps when the webcam container and video element will be re-used during
+   * the trial.
+   *
+   * @param maintain_container_size - Boolean indicating whether or not to set
+   *   the webcam feed container size before removing the video element
+   */
+  private clearWebcamFeed(maintain_container_size: boolean) {
     const webcam_feed_element = document.querySelector(
       `#${this.webcam_element_id}`,
     ) as HTMLVideoElement;
     if (webcam_feed_element) {
+      if (maintain_container_size) {
+        const parent_div = webcam_feed_element.parentElement as HTMLDivElement;
+        if (parent_div) {
+          const width = webcam_feed_element.offsetWidth;
+          const height = webcam_feed_element.offsetHeight;
+          parent_div.style.height = `${height}px`;
+          parent_div.style.width = `${width}px`;
+        }
+      }
       webcam_feed_element.remove();
     }
   }

--- a/packages/style/src/index.css
+++ b/packages/style/src/index.css
@@ -9250,4 +9250,5 @@ div#lookit-jspsych-video-config img.lookit-jspsych-checkmark {
 
 video.webcam-feed {
   transform: rotateY(180deg);
+  display: block;
 }


### PR DESCRIPTION
This PR fixes an issue with the page layout jumping when the recording stops. This was happening because the webcam container div fits the size of the video element, and the video element is removed when recording stops, which causes the div size to be resized. This PR fixes the issue by adding an optional boolean parameter to `recorder.stop` that, if true, sets the container div to be the same size as the video element before the video element is removed. The default is false in order to make this change backwards-compatible.

This PR also removes some space between the container div and video element by adding `display: block` to the video element.

## Screenshots

Before this change: layout jumps when recording stops.

https://github.com/user-attachments/assets/f9e4c1d1-3bcf-42e2-b0d2-c45d27dda351

After this change: when recording stops, the rest of the page content remains in place.

https://github.com/user-attachments/assets/6643816c-69b9-4c77-9fcd-b6b619591ac2

## Implementation notes

Another way of fixing this would be to always set the specific size of the container div. However, this would mean that the div would not automatically resize to match the video element's dimensions. We can revisit this solution if necessary.