### PR TITLE
RTD build: don't pass venv arg, use `active` flag

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,7 @@ build:
     post_create_environment:
       - pip install uv
     post_install:
-      # VIRTUAL_ENV needs to be set manually for now.
-      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --frozen
+      - uv sync --frozen --active
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
This is an attempt at fixing #160 

The lookit-jspsych RTD builds are failing following the switch from `poetry` to `uv`. I think the issue is with this line: `VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv sync --frozen`, which was a poetry-specific fix for telling poetry to use the RTD virtual environment. My current theory is that `uv` doesn't respect this directive and installs into a local `.venv` instead of using the RTD as it should. 

If this theory is correct, then it might be fixed by using the same command `uv sync --frozen` along with the [`active` flag](https://docs.astral.sh/uv/reference/cli/#uv-run--active), which tells uv to install into the active venv instead of creating one. 