### PR TITLE
RTD build: try activating the RTD venv before `uv sync`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,8 @@ build:
     post_create_environment:
       - pip install uv
     post_install:
-      - uv sync --frozen --active
+      - source $READTHEDOCS_VIRTUALENV_PATH/bin/activate && uv sync --frozen
+        --active
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
This is another attempt at fixing #160. PR #161 did not fix the issue - `uv` is still creating its own virtual environment, despite the `active` flag. This time I'm trying to manually activate the RTD venv before calling `uv sync --frozen --active`. 