### PR TITLE
RTD build: doesn't support `source` so try dot syntax

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,8 +13,7 @@ build:
     post_create_environment:
       - pip install uv
     post_install:
-      - source $READTHEDOCS_VIRTUALENV_PATH/bin/activate && uv sync --frozen
-        --active
+      - . $READTHEDOCS_VIRTUALENV_PATH/bin/activate && uv sync --frozen --active
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
This is another attempt at fixing https://github.com/lookit/lookit-jspsych/issues/160. PR https://github.com/lookit/lookit-jspsych/pull/162 did not fix the issue because `source` was not available in the RTD shell. So we can try using the dot syntax to activate the virtual environment.