### PR TITLE
Modify jsPsych data handling

### DIFF
--- a/.changeset/many-onions-pump.md
+++ b/.changeset/many-onions-pump.md
@@ -1,0 +1,8 @@
+---
+"@lookit/lookit-initjspsych": minor
+---
+
+Modify the on_data_update and on_finish (experiment) callbacks so that they do
+not retrieve the response sequence from the lookit-api and send it back with the
+response update request. The response sequence is now computed server-side, and
+no response retrieval is needed on each data update/save.

--- a/.changeset/poor-walls-relate.md
+++ b/.changeset/poor-walls-relate.md
@@ -1,0 +1,7 @@
+---
+"@lookit/lookit-initjspsych": minor
+---
+
+Modify the data update callback to send all experiment data back to the
+lookit-api endpoint on each data update, rather than retrieving the existing
+data from lookit-api and appending new data to the result.

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -40,3 +40,19 @@ export class UndefinedTimelineError extends Error {
     );
   }
 }
+
+/**
+ * Error when the jsPsych instance is not accessible in the on data update
+ * callback closure.
+ */
+export class NoJsPsychInstanceError extends Error {
+  /**
+   * Error when the jsPsych instance is not available in the on data update
+   * callback closure. The instance needs to be passed into the actual
+   * on_data_update callback in order to get all of the experiment data.
+   */
+  public constructor() {
+    super("No jsPsych instance availale for on_data_update.");
+    this.name = "NoJsPsychInstanceError";
+  }
+}

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -52,7 +52,7 @@ export class NoJsPsychInstanceError extends Error {
    * on_data_update callback in order to get all of the experiment data.
    */
   public constructor() {
-    super("No jsPsych instance availale for on_data_update.");
+    super("No jsPsych instance available for on_data_update.");
     this.name = "NoJsPsychInstanceError";
   }
 }

--- a/packages/lookit-initjspsych/src/errors.ts
+++ b/packages/lookit-initjspsych/src/errors.ts
@@ -1,12 +1,3 @@
-/** Error when experiment data doesn't contain values on finish. */
-export class SequenceExpDataError extends Error {
-  /** Error when experiment data doesn't contain values on finish. */
-  public constructor() {
-    super("Experiment sequence or data missing.");
-    this.name = "SequenceExpDataError";
-  }
-}
-
 /** When a trial type is accidentally undefined. */
 export class UndefinedTypeError extends Error {
   /**

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -141,7 +141,7 @@ describe("lookit-initjspsych initializes and runs", () => {
 
     // Track API mocks separately so we can assert on them
     const mockRetrieveResponse = jest.fn().mockResolvedValue({
-      attributes: { sequence: [], exp_data: [] },
+      attributes: { exp_data: [] },
     });
     const mockUpdateResponse = jest.fn().mockResolvedValue(undefined);
     const mockFinish = jest.fn().mockResolvedValue(undefined);
@@ -170,10 +170,9 @@ describe("lookit-initjspsych initializes and runs", () => {
       await expect(
         onDataUpdate({ trial_index: 0, trial_type: "test" } as unknown),
       ).resolves.not.toThrow();
-      expect(mockRetrieveResponse).toHaveBeenCalledWith("uuid");
+      expect(mockRetrieveResponse).not.toHaveBeenCalled();
       expect(mockUpdateResponse).toHaveBeenCalledWith("uuid", {
         exp_data: [], // from jsPsych.data.get().values()
-        sequence: ["0-test"], // sequence should contain the trial info
       });
       expect(mockFinish).toHaveBeenCalled();
     });

--- a/packages/lookit-initjspsych/src/index.spec.ts
+++ b/packages/lookit-initjspsych/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { JsPsych } from "jspsych";
+import * as jspsychModule from "jspsych";
 import TestPlugin from "../fixtures/TestPlugin";
 import lookitInitJsPsych from "./";
 import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
@@ -8,33 +8,31 @@ import type {
   ChsTrialDescription,
 } from "./types";
 
-describe("lookit-initjspsych", () => {
+describe("lookit-initjspsych initializes and runs", () => {
   beforeEach(() => {
     TestPlugin.reset();
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test("Does lookitInitJsPsych return an instance of jspsych?", () => {
+  test("lookitInitJsPsych returns an instance of jspsych", () => {
     const jsPsych = lookitInitJsPsych("uuid-string");
     const opts = {
       on_data_update: jest.fn(),
       on_finish: jest.fn(),
     };
-    expect(jsPsych(opts)).toBeInstanceOf(JsPsych);
+    expect(jsPsych(opts)).toBeInstanceOf(jspsychModule.JsPsych);
   });
 
-  test("Is jspsych's run called?", async () => {
+  test("jsPsych's run is called", async () => {
     const mockRun = jest.fn();
-    jest.spyOn(JsPsych.prototype, "run").mockImplementation(mockRun);
+    jest
+      .spyOn(jspsychModule.JsPsych.prototype, "run")
+      .mockImplementation(mockRun);
     const jsPsych = lookitInitJsPsych("some id");
     await jsPsych({}).run([]);
     expect(mockRun).toHaveBeenCalledTimes(1);
   });
 
-  test("Is experiment data injected into timeline w/o data?", async () => {
+  test("Experiment data is injected into timeline w/o data", async () => {
     const jsPsych = lookitInitJsPsych("some id");
     const trial: ChsTrialDescription = { type: TestPlugin };
     const t: ChsTimelineArray = [trial];
@@ -46,7 +44,7 @@ describe("lookit-initjspsych", () => {
     });
   });
 
-  test("Is experiment data injected into timeline w/ data?", async () => {
+  test("Experiment data is injected into timeline w/ data", async () => {
     const jsPsych = lookitInitJsPsych("some id");
     const trial: ChsTrialDescription = {
       type: TestPlugin,
@@ -59,6 +57,12 @@ describe("lookit-initjspsych", () => {
       chs_type: "test",
       other: "data",
     });
+  });
+});
+
+describe("lookit-initjspsych timeline/trial handling", () => {
+  beforeEach(() => {
+    TestPlugin.reset();
   });
 
   test("Throws UndefinedTypeError when trial description has no type", () => {

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -62,7 +62,7 @@ const isTrialWithType = (
  * @returns InitJsPsych function.
  */
 const lookitInitJsPsych = (responseUuid: string) => {
-  return function (opts: JsPsychOptions): ChsJsPsych {
+  return function (opts?: JsPsychOptions): ChsJsPsych {
     // Omit on_data_update from user-defined options that will be passed into origInitJsPsych.
     // We are using a closure in the on_data_update function so that we can reference the jsPsych instance,
     // and the user-defined function will be passed in through that closure.

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -2,11 +2,7 @@ import { JsPsychExpData } from "@lookit/data/dist/types";
 import type { JsPsych as JsPsychType } from "jspsych";
 import * as jspsychModule from "jspsych";
 import type { TimelineArray } from "jspsych/src/timeline";
-import {
-  NoJsPsychInstanceError,
-  UndefinedTimelineError,
-  UndefinedTypeError,
-} from "./errors";
+import { UndefinedTimelineError, UndefinedTypeError } from "./errors";
 import type {
   ChsJsPsych,
   ChsTimelineArray,
@@ -83,16 +79,14 @@ const lookitInitJsPsych = (responseUuid: string) => {
      * @returns The on_data_update function to be used
      */
     const onDataUpdate = (...args: [JsPsychExpData]) => {
-      if (jsPsychInstance) {
-        // Call the custom CHS on_data_update fn with the jsPsych instance, response UUID,
-        // and the user-defined on_data_update function if it exists (our on_data_update fn handles the undefined case).
-        return on_data_update(
-          jsPsychInstance,
-          responseUuid,
-          userOnDataUpdate,
-        )(...args);
-      }
-      throw new NoJsPsychInstanceError();
+      // Call the custom CHS on_data_update fn with the jsPsych instance, response UUID,
+      // and the user-defined on_data_update function if it exists.
+      // No checks for jsPsychInstance here because on_data_update handles that.
+      return on_data_update(
+        jsPsychInstance,
+        responseUuid,
+        userOnDataUpdate,
+      )(...args);
     };
 
     // Create the jsPsych instance and pass in the callbacks

--- a/packages/lookit-initjspsych/src/index.ts
+++ b/packages/lookit-initjspsych/src/index.ts
@@ -1,5 +1,6 @@
 import { JsPsychExpData } from "@lookit/data/dist/types";
-import { initJsPsych as origInitJsPsych, JsPsych } from "jspsych";
+import type { JsPsych as JsPsychType } from "jspsych";
+import * as jspsychModule from "jspsych";
 import type { TimelineArray } from "jspsych/src/timeline";
 import {
   NoJsPsychInstanceError,
@@ -72,7 +73,7 @@ const lookitInitJsPsych = (responseUuid: string) => {
     const { on_data_update: userOnDataUpdate, ...otherOpts } = opts || {};
 
     // Create a placeholder for the instance - needed for use in the onDataUpdate closure.
-    let jsPsychInstance: JsPsych | null = null;
+    let jsPsychInstance: JsPsychType | null = null;
 
     /**
      * Closure to return the on_data_update function, with the actual instance,
@@ -95,7 +96,7 @@ const lookitInitJsPsych = (responseUuid: string) => {
     };
 
     // Create the jsPsych instance and pass in the callbacks
-    const jsPsych = origInitJsPsych({
+    const jsPsych = jspsychModule.initJsPsych({
       ...otherOpts,
       on_data_update: onDataUpdate,
       on_finish: on_finish(responseUuid, opts?.on_finish),

--- a/packages/lookit-initjspsych/src/utils.spec.ts
+++ b/packages/lookit-initjspsych/src/utils.spec.ts
@@ -1,12 +1,24 @@
 import { DataCollection, JsPsych } from "jspsych";
 
 import { Child, JsPsychExpData, Study } from "@lookit/data/dist/types";
-import { NoJsPsychInstanceError, SequenceExpDataError } from "./errors";
+import { NoJsPsychInstanceError } from "./errors";
 import { on_data_update, on_finish } from "./utils";
 
 delete global.window.location;
 global.window = Object.create(window);
 global.window.location = { replace: jest.fn() };
+// Even though we're not using Api.retrieveResponse in on_data_update/on_finish anymore, we still need to mock fetch because it is used to send the PATCH request.
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    /**
+     * Mock json method and returned data object.
+     *
+     * @returns Promise that resolves with a data attribute.
+     */
+    json: () => Promise.resolve({ data: {} }),
+  } as Response),
+);
 
 test("jsPsych's on_data_update with some exp_data", async () => {
   // mock jsPsych data
@@ -33,25 +45,10 @@ test("jsPsych's on_data_update with some exp_data", async () => {
   };
   expect(jsPsychMock.data.get().values()).toEqual(mockTrialData);
 
-  // mock lookit API data
-  const jsonData = {
-    data: {
-      attributes: { sequence: ["0-first-trial"] },
-    },
-  };
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
-  const data = {} as JsPsychExpData;
+  // on_data_update receives the latest data addition as its argument
+  const data = { trial_index: 1, trial_type: "survey" } as JsPsychExpData;
 
   const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
   global.Request = jest.fn();
 
   expect(
@@ -59,8 +56,7 @@ test("jsPsych's on_data_update with some exp_data", async () => {
   ).toBeUndefined();
   expect(userFn).toHaveBeenCalledTimes(1);
   expect(userFn).toHaveBeenCalledWith(data);
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(Request).toHaveBeenCalledTimes(2);
+  expect(Request).toHaveBeenCalledTimes(1);
 });
 
 test("jsPsych's on_data_update with no exp_data", async () => {
@@ -85,53 +81,24 @@ test("jsPsych's on_data_update with no exp_data", async () => {
   };
   expect(jsPsychMock.data.get().values()).toEqual(mockTrialData);
 
-  // mock lookit API data
-  const jsonData = {
-    data: { attributes: { sequence: undefined } },
-  };
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
   const data = {} as JsPsychExpData;
 
   const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
   global.Request = jest.fn();
 
   expect(
     await on_data_update(jsPsychMock as JsPsych, "some id", userFn)(data),
   ).toBeUndefined();
   expect(userFn).toHaveBeenCalledTimes(1);
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(Request).toHaveBeenCalledTimes(2);
+  expect(Request).toHaveBeenCalledTimes(1);
 });
 
 test("Error throws if jsPsych instance is null", () => {
   const jsPsychInstance: JsPsych | null = null;
 
-  // mock lookit API data
-  const jsonData = {
-    data: { attributes: { sequence: undefined } },
-  };
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
   const data = {} as JsPsychExpData;
 
   const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
   global.Request = jest.fn();
 
   expect(async () => {
@@ -146,23 +113,9 @@ test("Error throws if jsPsych instance is null", () => {
 test("Error throws if jsPsych instance is undefined", () => {
   const jsPsychInstance: JsPsych | undefined = undefined;
 
-  // mock lookit API data
-  const jsonData = {
-    data: { attributes: { sequence: undefined } },
-  };
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
   const data = {} as JsPsychExpData;
 
   const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
   global.Request = jest.fn();
 
   expect(async () => {
@@ -176,11 +129,6 @@ test("Error throws if jsPsych instance is undefined", () => {
 
 test("jsPsych's on_finish", async () => {
   const exp_data = [{ key: "value" }];
-  const jsonData = {
-    data: {
-      attributes: { exp_data, sequence: ["0-value"] },
-    },
-  };
   const data = {
     /**
      * Mocked jsPsych Data Collection.
@@ -189,18 +137,8 @@ test("jsPsych's on_finish", async () => {
      */
     values: () => exp_data,
   } as DataCollection;
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
 
   const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
   global.Request = jest.fn();
 
   Object.assign(window, {
@@ -214,48 +152,5 @@ test("jsPsych's on_finish", async () => {
   expect(await on_finish("some id", userFn)(data)).toBeUndefined();
   expect(userFn).toHaveBeenCalledTimes(1);
   expect(userFn).toHaveBeenCalledWith(data);
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(Request).toHaveBeenCalledTimes(2);
-});
-
-test("Is an error thrown when experiment sequence is undefined?", () => {
-  const exp_data = [{ key: "value" }];
-  const jsonData = {
-    data: {
-      attributes: { exp_data, sequence: undefined },
-    },
-  };
-  const data = {
-    /**
-     * Mocked jsPsych Data Collection.
-     *
-     * @returns Exp data.
-     */
-    values: () => exp_data,
-  } as DataCollection;
-  const response = {
-    /**
-     * Mocked json function used in API calls.
-     *
-     * @returns Promise containing mocked json data.
-     */
-    json: () => Promise.resolve(jsonData),
-    ok: true,
-  } as Response;
-
-  const userFn = jest.fn();
-  global.fetch = jest.fn(() => Promise.resolve(response));
-  global.Request = jest.fn();
-
-  Object.assign(window, {
-    chs: {
-      study: { attributes: { exit_url: "exit url" } } as Study,
-      child: {} as Child,
-      pastSessions: {} as Response[],
-    },
-  });
-
-  expect(async () => {
-    await on_finish("some id", userFn)(data);
-  }).rejects.toThrow(SequenceExpDataError);
+  expect(Request).toHaveBeenCalledTimes(1);
 });

--- a/packages/lookit-initjspsych/src/utils.spec.ts
+++ b/packages/lookit-initjspsych/src/utils.spec.ts
@@ -112,8 +112,39 @@ test("jsPsych's on_data_update with no exp_data", async () => {
   expect(Request).toHaveBeenCalledTimes(2);
 });
 
-test("Error throws if no jsPsych instance is found", () => {
+test("Error throws if jsPsych instance is null", () => {
   const jsPsychInstance: JsPsych | null = null;
+
+  // mock lookit API data
+  const jsonData = {
+    data: { attributes: { sequence: undefined } },
+  };
+  const response = {
+    /**
+     * Mocked json function used in API calls.
+     *
+     * @returns Promise containing mocked json data.
+     */
+    json: () => Promise.resolve(jsonData),
+    ok: true,
+  } as Response;
+  const data = {} as JsPsychExpData;
+
+  const userFn = jest.fn();
+  global.fetch = jest.fn(() => Promise.resolve(response));
+  global.Request = jest.fn();
+
+  expect(async () => {
+    await on_data_update(
+      jsPsychInstance as unknown as JsPsych,
+      "some id",
+      userFn,
+    )(data);
+  }).rejects.toThrow(NoJsPsychInstanceError);
+});
+
+test("Error throws if jsPsych instance is undefined", () => {
+  const jsPsychInstance: JsPsych | undefined = undefined;
 
   // mock lookit API data
   const jsonData = {

--- a/packages/lookit-initjspsych/src/utils.ts
+++ b/packages/lookit-initjspsych/src/utils.ts
@@ -1,7 +1,7 @@
 import Api from "@lookit/data";
 import { JsPsychExpData, LookitWindow } from "@lookit/data/dist/types";
 import { DataCollection, JsPsych } from "jspsych";
-import { NoJsPsychInstanceError, SequenceExpDataError } from "./errors";
+import { NoJsPsychInstanceError } from "./errors";
 import { UserFuncOnDataUpdate, UserFuncOnFinish } from "./types";
 
 declare let window: LookitWindow;
@@ -28,12 +28,8 @@ export const on_data_update = (
       throw new NoJsPsychInstanceError();
     }
 
-    const { attributes } = await Api.retrieveResponse(responseUuid);
-    const sequence = attributes.sequence ? attributes.sequence : [];
-
     await Api.updateResponse(responseUuid, {
       exp_data: jsPsychInstance.data.get().values() as JsPsychExpData[],
-      sequence: [...sequence, `${data.trial_index}-${data.trial_type}`],
     });
     await Api.finish();
 
@@ -61,18 +57,9 @@ export const on_finish = (
   userFunc?: UserFuncOnFinish,
 ) => {
   return async function (data: DataCollection) {
-    const {
-      attributes: { sequence },
-    } = await Api.retrieveResponse(responseUuid);
-
     const exp_data: JsPsychExpData[] = data.values();
 
-    if (!Array.isArray(sequence)) {
-      throw new SequenceExpDataError();
-    }
-
     const { exit_url } = window.chs.study.attributes;
-    const last_exp = exp_data[exp_data.length - 1];
 
     // Don't call the function if not defined by user.
     if (typeof userFunc === "function") {
@@ -81,7 +68,6 @@ export const on_finish = (
 
     await Api.updateResponse(responseUuid, {
       exp_data,
-      sequence: [...sequence, `${last_exp.trial_index}-${last_exp.trial_type}`],
       completed: true,
     })
       .then(() => Api.finish())

--- a/packages/lookit-initjspsych/src/utils.ts
+++ b/packages/lookit-initjspsych/src/utils.ts
@@ -19,7 +19,7 @@ declare let window: LookitWindow;
  * @returns On data update function.
  */
 export const on_data_update = (
-  jsPsychInstance: JsPsych,
+  jsPsychInstance: JsPsych | undefined | null,
   responseUuid: string,
   userFunc?: UserFuncOnDataUpdate,
 ) => {


### PR DESCRIPTION
This PR partly addresses #170 but should not close that issue.

## Summary of changes

Our custom `on_data_update` function now sends _all of the experiment data_ to the lookit-api end point on each update, rather than retrieving the existing data from lookit-api and appending the new data to that. 

This solution is more robust to intermittent data saving failures/corruption during the experiment, because we are saving the 'ground truth' copy of the data and not appending to our existing data copy, which could be missing data if any previous API requests failed. And there should not changes to the network load (we were already retrieving all of the data and sending all of it back on each update - now we are still sending it all back but eliminating the initial data retrieval).

This PR also includes all changes described in #178

## Implementation notes

The most important changes are in this file: `packages/lookit-initjspsych/src/utils.ts`. 

The thing that made this change difficult is that (a) jsPsych's [`on_data_update` callback function](https://www.jspsych.org/latest/overview/events/#on_data_update) only passes in the newly-updated data and (b) it is defined in `initJsPsych` (before the jsPsych instance is created). This means that was not possible for us to call `jsPsych.data.get` inside that callback function. But since we are creating an instance inside the `lookitJsPsychInit` wrapper, I could access the jsPsych instance using a closure. This is the reason for all of the changes in `packages/lookit-initjspsych/src/index.ts`. Instead of passing our custom `on_data_update` into the original `initJsPsych`, I had to do the following:
1. Create a placeholder variable for the jsPsych instance
2. Create the `onDataUpdate` closure that passes the instance into our custom `on_data_update` callback function.
3. Initialize jsPsych using the `onDataUpdate` closure as the value of the `on_data_update` init parameter.
4. Update the value of the jsPsych instance variable with the actual instance that was created in (3).

This approach meant that we could add the jsPsych instance to the set of arguments passed from our closure to to our custom `on_data_update` callback function, and then use that to get all of the experiment data (`jsPsychInstance.data.get`).

As side effects of these changes, I also:
- added a new error type to catch the case where the jsPsych instance is not valid inside `on_data_update`
- added a lot of tests
- modified the way that we import jsPsych (namespace rather than named), because named imports were causing problems for mocking jsPsych in tests
