### PR TITLE
Edit release.yml to remove npm token and use OIDC instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -46,6 +50,3 @@ jobs:
           version: npx changeset version
           publish: npx changeset publish
           commit: "chore(release): version packages"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We've been using NPM tokens with 2FA disabled for our GH release action. This PR is to try out NPM's 'trusted publishers' method instead of tokens. If this is successful then I'll update our docs as well.