### PR TITLE
fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
   packages: write
 
 jobs:
@@ -51,3 +52,4 @@ jobs:
           version: npx changeset version
           publish: npx changeset publish
           commit: "chore(release): version packages"
+          createGithubReleases: true


### PR DESCRIPTION
This PR is another attempt at fixing the workflow/release.yml permissions to work with NPM's OIDC auth method.